### PR TITLE
Update to use pyasic to handle miners and data

### DIFF
--- a/.cookiecutter.json
+++ b/.cookiecutter.json
@@ -3,7 +3,7 @@
   "class_name_prefix": "Miner",
   "domain_name": "miner",
   "friendly_name": "miner",
-  "github_user": "Schnitzel",
+  "github_user": "UpstreamData",
   "project_name": "miner",
   "test_suite": "yes",
   "version": "0.0.0"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Uses [pyasic](https://github.com/UpstreamData/pyasic) by [UpstreamData](https://
 
 ## Installation
 
-Use HACS, add the custom repo https://github.com/Schnitzel/hass-miner to it
+Use HACS, add the custom repo https://github.com/UpstreamData/hass-miner to it
 
 Installation and usage:
 
@@ -45,10 +45,10 @@ Code template was mainly taken from [@Ludeeus](https://github.com/ludeeus)'s [in
 [integration_blueprint]: https://github.com/custom-components/integration_blueprint
 [black]: https://github.com/psf/black
 [black-shield]: https://img.shields.io/badge/code%20style-black-000000.svg?style=for-the-badge
-[buymecoffee]: https://www.buymeacoffee.com/Schnitzel
+[buymecoffee]: https://www.buymeacoffee.com/UpstreamData
 [buymecoffeebadge]: https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg?style=for-the-badge
-[commits-shield]: https://img.shields.io/github/commit-activity/y/Schnitzel/hass-miner.svg?style=for-the-badge
-[commits]: https://github.com/Schnitzel/hass-miner/commits/main
+[commits-shield]: https://img.shields.io/github/commit-activity/y/UpstreamData/hass-miner.svg?style=for-the-badge
+[commits]: https://github.com/UpstreamData/hass-miner/commits/main
 [hacs]: https://hacs.xyz
 [hacsbadge]: https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge
 [discord]: https://discord.gg/Qa5fW2R
@@ -56,10 +56,10 @@ Code template was mainly taken from [@Ludeeus](https://github.com/ludeeus)'s [in
 [exampleimg]: example.png
 [forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg?style=for-the-badge
 [forum]: https://community.home-assistant.io/
-[license-shield]: https://img.shields.io/github/license/Schnitzel/hass-miner.svg?style=for-the-badge
-[maintenance-shield]: https://img.shields.io/badge/maintainer-%40Schnitzel-blue.svg?style=for-the-badge
+[license-shield]: https://img.shields.io/github/license/UpstreamData/hass-miner.svg?style=for-the-badge
+[maintenance-shield]: https://img.shields.io/badge/maintainer-%40UpstreamData-blue.svg?style=for-the-badge
 [pre-commit]: https://github.com/pre-commit/pre-commit
 [pre-commit-shield]: https://img.shields.io/badge/pre--commit-enabled-brightgreen?style=for-the-badge
-[releases-shield]: https://img.shields.io/github/release/Schnitzel/hass-miner.svg?style=for-the-badge
-[releases]: https://github.com/Schnitzel/hass-miner/releases
-[user_profile]: https://github.com/Schnitzel
+[releases-shield]: https://img.shields.io/github/release/UpstreamData/hass-miner.svg?style=for-the-badge
+[releases]: https://github.com/UpstreamData/hass-miner/releases
+[user_profile]: https://github.com/UpstreamData

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Controll your Braiins OS+ enabled Bitcoin miner from Home Assistant.
 
-Uses a [forked](https://github.com/Schnitzel/minerInterface) version of the awesome [minerInterface](https://github.com/UpstreamData/minerInterface) by [UpstreamData](https://github.com/UpstreamData) to talk to the APIs of the miners
+Uses [pyasic](https://github.com/UpstreamData/pyasic) by [UpstreamData](https://github.com/UpstreamData) to talk to the APIs of the miners.
 
 **This component will set up the following platforms.**
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![hacs][hacsbadge]][hacs]
 [![Project Maintenance][maintenance-shield]][user_profile]
 
-Controll your Braiins OS+ enabled Bitcoin miner from Home Assistant.
+Control your Braiins OS+ enabled Bitcoin miner from Home Assistant.
 
 Uses [pyasic](https://github.com/UpstreamData/pyasic) by [UpstreamData](https://github.com/UpstreamData) to talk to the APIs of the miners.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# miner
+# hass-miner
 
 [![GitHub Release][releases-shield]][releases]
 [![GitHub Activity][commits-shield]][commits]
@@ -10,11 +10,11 @@
 [![hacs][hacsbadge]][hacs]
 [![Project Maintenance][maintenance-shield]][user_profile]
 
-Control your Braiins OS+ enabled Bitcoin miner from Home Assistant.
+Control your Bitcoin miner from Home Assistant.
 
-Uses [pyasic](https://github.com/UpstreamData/pyasic) by [UpstreamData](https://github.com/UpstreamData) to talk to the APIs of the miners.
+### [Supported miners are listed here](https://pyasic.readthedocs.io/en/latest/miners/supported_types/).
 
-**This component will set up the following platforms.**
+**This component will set up the following platforms -**
 
 | Platform | Description               |
 | -------- | ------------------------- |
@@ -38,7 +38,9 @@ If you want to contribute to this please read the [Contribution guidelines](CONT
 
 This project was generated from [@oncleben31](https://github.com/oncleben31)'s [Home Assistant Custom Component Cookiecutter](https://github.com/oncleben31/cookiecutter-homeassistant-custom-component) template.
 
-Code template was mainly taken from [@Ludeeus](https://github.com/ludeeus)'s [integration_blueprint][integration_blueprint] template
+Code template was mainly taken from [@Ludeeus](https://github.com/ludeeus)'s [integration_blueprint][integration_blueprint] template.
+
+Miner control and data is handled using [@UpstreamData](https://github.com/UpstreamData)'s [pyasic](https://github.com/UpstreamData/pyasic).
 
 ---
 

--- a/custom_components/miner/__init__.py
+++ b/custom_components/miner/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from pyasic.miners.miner_factory import MinerFactory
 
 from .const import DOMAIN
 from .coordinator import MinerCoordinator

--- a/custom_components/miner/__init__.py
+++ b/custom_components/miner/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from miners.miner_factory import MinerFactory
+from pyasic.miners.miner_factory import MinerFactory
 
 from .const import DOMAIN
 from .coordinator import MinerCoordinator
@@ -17,8 +17,7 @@ PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SWITCH, Platform.NUMBER]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Miner from a config entry."""
 
-    miner_factory = MinerFactory()
-    coordinator = MinerCoordinator(hass, entry, miner_factory)
+    coordinator = MinerCoordinator(hass, entry)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)

--- a/custom_components/miner/__init__.py
+++ b/custom_components/miner/__init__.py
@@ -16,17 +16,18 @@ PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SWITCH, Platform.NUMBER]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Miner from a config entry."""
 
-    coordinator = MinerCoordinator(hass, entry)
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    m_coordinator = MinerCoordinator(hass, entry)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = m_coordinator
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/custom_components/miner/config_flow.py
+++ b/custom_components/miner/config_flow.py
@@ -1,11 +1,11 @@
 """Config flow for Miner."""
 import logging
 
+import pyasic.miners.unknown
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant import core
 from homeassistant import exceptions
-from pyasic.API import APIError
 from pyasic.miners.miner_factory import MinerFactory
 
 from .const import CONF_HOSTNAME
@@ -32,9 +32,8 @@ async def validate_input(
     miner_ip = data.get(CONF_IP)
     try:
         miner = await MinerFactory().get_miner(miner_ip)
-        await miner.api.summary()
-    except APIError:
-        return {"base": "cannot_connect"}
+        if isinstance(miner, pyasic.miners.unknown.UnknownMiner):
+            return {"base": "cannot_connect"}
     except Exception:  # pylint: disable=broad-except
         _LOGGER.exception("Unexpected exception")
         return {"base": "unknown"}

--- a/custom_components/miner/config_flow.py
+++ b/custom_components/miner/config_flow.py
@@ -1,11 +1,10 @@
 """Config flow for Miner."""
 import logging
 
+import pyasic
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant import core
 from homeassistant import exceptions
-import pyasic
 
 from .const import CONF_HOSTNAME
 from .const import CONF_IP
@@ -62,7 +61,9 @@ class MinerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if not user_input:
             return self.async_show_form(step_id="user", data_schema=schema)
 
-        if not (errors := await validate_input(user_input)):
+        errors = await validate_input(user_input)
+
+        if not errors:
             self._data.update(user_input)
             return await self.async_step_hostname()
 

--- a/custom_components/miner/config_flow.py
+++ b/custom_components/miner/config_flow.py
@@ -75,7 +75,7 @@ class MinerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         miner_ip = self._data.get(CONF_IP)
         miner = await MinerFactory().get_miner(miner_ip)
-        miner_data = await miner.get_data()
+        hn = await miner.get_hostname()
 
         if user_input is None:
             user_input = {}
@@ -84,7 +84,7 @@ class MinerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(
                     CONF_HOSTNAME,
-                    default=user_input.get(CONF_HOSTNAME, miner_data.hostname),
+                    default=user_input.get(CONF_HOSTNAME, hn),
                 ): str,
             }
         )

--- a/custom_components/miner/const.py
+++ b/custom_components/miner/const.py
@@ -3,3 +3,5 @@
 DOMAIN = "miner"
 CONF_IP = "ip"
 CONF_HOSTNAME = "hostname"
+CONF_PASSWORD = "password"
+CONF_USERNAME = "username"

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -1,17 +1,14 @@
 """IoTaWatt DataUpdateCoordinator."""
-from __future__ import annotations
-
 import logging
 from datetime import timedelta
+from typing import Union
 
+import pyasic
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.update_coordinator import UpdateFailed
-from pyasic.API import APIError
-from pyasic.miners import BaseMiner
-from pyasic.miners.miner_factory import MinerFactory
 
 from .const import CONF_IP
 
@@ -24,7 +21,7 @@ REQUEST_REFRESH_DEFAULT_COOLDOWN = 5
 class MinerCoordinator(DataUpdateCoordinator):
     """Class to manage fetching update data from the IoTaWatt Energy Device."""
 
-    miner: BaseMiner | None = None
+    miner: Union[pyasic.AnyMiner, None] = None
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize MinerCoordinator object."""
@@ -32,7 +29,7 @@ class MinerCoordinator(DataUpdateCoordinator):
         super().__init__(
             hass=hass,
             logger=_LOGGER,
-            name=entry.title,
+            name=entry.title, # hostname for now
             update_interval=timedelta(seconds=10),
             request_refresh_debouncer=Debouncer(
                 hass,
@@ -49,10 +46,10 @@ class MinerCoordinator(DataUpdateCoordinator):
 
         try:
             if self.miner is None:
-                self.miner = await MinerFactory().get_miner(miner_ip)
+                self.miner = await pyasic.get_miner(miner_ip)
             miner_data = await self.miner.get_data()
 
-        except APIError as err:
+        except pyasic.APIError as err:
             raise UpdateFailed("API Error") from err
 
         data = {
@@ -63,10 +60,10 @@ class MinerCoordinator(DataUpdateCoordinator):
             "ip": self.miner.ip,
             "miner_sensors": {
                 "hashrate": int(miner_data.hashrate),
+                "ideal_hashrate": int(miner_data.nominal_hashrate),
                 "temperature": int(miner_data.temperature_avg),
                 "power_limit": miner_data.wattage_limit,
                 "miner_consumption": miner_data.wattage,
-                "scaled_power_limit": None,
             },
             "board_sensors": {
                 board.slot: {
@@ -77,27 +74,5 @@ class MinerCoordinator(DataUpdateCoordinator):
                 for board in miner_data.hashboards
             },
         }
-        # data["hostname"] = self.entry.data[CONF_HOSTNAME]
-        # data["version"] = miner_data.version
-
-        if "tunerstatus" in self.miner.api.get_commands():
-            tuner_data = await self.miner.api.tunerstatus()
-
-            tuner = tuner_data.get("TUNERSTATUS")
-            if tuner:
-                if len(tuner) > 0:
-                    dynamic_power_scaling = tuner[0].get("DynamicPowerScaling")
-                    if isinstance(dynamic_power_scaling, dict):
-                        scaled_power_limit = dynamic_power_scaling.get(
-                            "ScaledPowerLimit"
-                        )
-                        if scaled_power_limit:
-                            data["miner_sensors"][
-                                "scaled_power_limit"
-                            ] = scaled_power_limit
-                    elif dynamic_power_scaling == "InitialPowerLimit":
-                        data["miner_sensors"][
-                            "scaled_power_limit"
-                        ] = miner_data.wattage_limit
 
         return data

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -64,6 +64,7 @@ class MinerCoordinator(DataUpdateCoordinator):
                 "temperature": int(miner_data.temperature_avg),
                 "power_limit": miner_data.wattage_limit,
                 "miner_consumption": miner_data.wattage,
+                "is_mining": miner_data.is_mining,
             },
             "board_sensors": {
                 board.slot: {

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -64,7 +64,6 @@ class MinerCoordinator(DataUpdateCoordinator):
                 "temperature": int(miner_data.temperature_avg),
                 "power_limit": miner_data.wattage_limit,
                 "miner_consumption": miner_data.wattage,
-                "is_mining": miner_data.is_mining,
             },
             "board_sensors": {
                 board.slot: {

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -59,8 +59,8 @@ class MinerCoordinator(DataUpdateCoordinator):
             "model": miner_data.model,
             "ip": self.miner.ip,
             "miner_sensors": {
-                "hashrate": int(miner_data.hashrate),
-                "ideal_hashrate": int(miner_data.nominal_hashrate),
+                "hashrate": miner_data.hashrate,
+                "ideal_hashrate": miner_data.nominal_hashrate,
                 "temperature": int(miner_data.temperature_avg),
                 "power_limit": miner_data.wattage_limit,
                 "miner_consumption": miner_data.wattage,

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -58,6 +58,7 @@ class MinerCoordinator(DataUpdateCoordinator):
             "make": miner_data.make,
             "model": miner_data.model,
             "ip": self.miner.ip,
+            "is_mining": miner_data.is_mining,
             "miner_sensors": {
                 "hashrate": miner_data.hashrate,
                 "ideal_hashrate": miner_data.nominal_hashrate,

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -78,19 +78,24 @@ class MinerCoordinator(DataUpdateCoordinator):
             for board in miner_data.hashboards
         }
 
-        miner_api_data = await self.miner.api.multicommand("tunerstatus")
+        if "tunerstatus" in self.miner.api.get_commands():
+            miner_api_data = await self.miner.api.tunerstatus()
 
-        tuner = miner_api_data.get("tunerstatus")[0].get("TUNERSTATUS")
-        if tuner:
-            if len(tuner) > 0:
-                dynamic_power_scaling = tuner[0].get("DynamicPowerScaling")
-                if isinstance(dynamic_power_scaling, dict):
-                    scaled_power_limit = dynamic_power_scaling.get("ScaledPowerLimit")
-                    if scaled_power_limit:
-                        data["miner_sensors"]["scaled_power_limit"] = scaled_power_limit
-                elif dynamic_power_scaling == "InitialPowerLimit":
-                    data["miner_sensors"][
-                        "scaled_power_limit"
-                    ] = miner_api_data.wattage_limit
+            tuner = miner_api_data.get("TUNERSTATUS")
+            if tuner:
+                if len(tuner) > 0:
+                    dynamic_power_scaling = tuner[0].get("DynamicPowerScaling")
+                    if isinstance(dynamic_power_scaling, dict):
+                        scaled_power_limit = dynamic_power_scaling.get(
+                            "ScaledPowerLimit"
+                        )
+                        if scaled_power_limit:
+                            data["miner_sensors"][
+                                "scaled_power_limit"
+                            ] = scaled_power_limit
+                    elif dynamic_power_scaling == "InitialPowerLimit":
+                        data["miner_sensors"][
+                            "scaled_power_limit"
+                        ] = miner_api_data.wattage_limit
 
         return data

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -55,28 +55,30 @@ class MinerCoordinator(DataUpdateCoordinator):
         except APIError as err:
             raise UpdateFailed("API Error") from err
 
-        data = {}
+        data = {
+            "hostname": miner_data.hostname,
+            "mac": miner_data.mac,
+            "make": miner_data.make,
+            "model": miner_data.model,
+            "ip": self.miner.ip,
+            "miner_sensors": {
+                "hashrate": int(miner_data.hashrate),
+                "temperature": int(miner_data.temperature_avg),
+                "power_limit": miner_data.wattage_limit,
+                "miner_consumption": miner_data.wattage,
+                "scaled_power_limit": None,
+            },
+            "board_sensors": {
+                board.slot: {
+                    "board_temperature": board.temp,
+                    "chip_temperature": board.chip_temp,
+                    "board_hashrate": board.hashrate,
+                }
+                for board in miner_data.hashboards
+            },
+        }
         # data["hostname"] = self.entry.data[CONF_HOSTNAME]
-        data["hostname"] = miner_data.hostname
-        data["model"] = miner_data.model
-        data["ip"] = self.miner.ip
         # data["version"] = miner_data.version
-        data["miner_sensors"] = {
-            "hashrate": int(miner_data.hashrate),
-            "temperature": int(miner_data.temperature_avg),
-            "power_limit": miner_data.wattage_limit,
-            "miner_consumption": miner_data.wattage,
-            "scaled_power_limit": None,
-        }
-
-        data["board_sensors"] = {
-            board.slot: {
-                "board_temperature": board.temp,
-                "chip_temperature": board.chip_temp,
-                "board_hashrate": board.hashrate,
-            }
-            for board in miner_data.hashboards
-        }
 
         if "tunerstatus" in self.miner.api.get_commands():
             tuner_data = await self.miner.api.tunerstatus()

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -13,7 +13,6 @@ from pyasic.API import APIError
 from pyasic.miners import BaseMiner
 from pyasic.miners.miner_factory import MinerFactory
 
-from .const import CONF_HOSTNAME
 from .const import CONF_IP
 
 _LOGGER = logging.getLogger(__name__)
@@ -71,21 +70,12 @@ class MinerCoordinator(DataUpdateCoordinator):
         }
 
         data["board_sensors"] = {
-            0: {
-                "board_temperature": miner_data.left_board_temp,
-                "chip_temperature": miner_data.left_board_chip_temp,
-                "board_hashrate": miner_data.left_board_hashrate,
-            },
-            1: {
-                "board_temperature": miner_data.center_board_temp,
-                "chip_temperature": miner_data.center_board_chip_temp,
-                "board_hashrate": miner_data.center_board_hashrate,
-            },
-            2: {
-                "board_temperature": miner_data.right_board_temp,
-                "chip_temperature": miner_data.right_board_chip_temp,
-                "board_hashrate": miner_data.right_board_hashrate,
-            },
+            board.slot: {
+                "board_temperature": board.temp,
+                "chip_temperature": board.chip_temp,
+                "board_hashrate": board.hashrate,
+            }
+            for board in miner_data.hashboards
         }
 
         miner_api_data = await self.miner.api.multicommand("tunerstatus")

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -79,9 +79,9 @@ class MinerCoordinator(DataUpdateCoordinator):
         }
 
         if "tunerstatus" in self.miner.api.get_commands():
-            miner_api_data = await self.miner.api.tunerstatus()
+            tuner_data = await self.miner.api.tunerstatus()
 
-            tuner = miner_api_data.get("TUNERSTATUS")
+            tuner = tuner_data.get("TUNERSTATUS")
             if tuner:
                 if len(tuner) > 0:
                     dynamic_power_scaling = tuner[0].get("DynamicPowerScaling")
@@ -96,6 +96,6 @@ class MinerCoordinator(DataUpdateCoordinator):
                     elif dynamic_power_scaling == "InitialPowerLimit":
                         data["miner_sensors"][
                             "scaled_power_limit"
-                        ] = miner_api_data.wattage_limit
+                        ] = miner_data.wattage_limit
 
         return data

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,11 +4,11 @@
   "issue_tracker": "https://github.com/UpstreamData/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/UpstreamData/hass-miner",
-  "requirements": ["pyasic==0.30.11"],
+  "requirements": ["pyasic==0.32.3"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},
   "codeowners": ["@UpstreamData"],
   "iot_class": "local_polling",
-  "version": "0.6.0"
+  "version": "0.7.0"
 }

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,11 +4,10 @@
   "issue_tracker": "https://github.com/Schnitzel/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/Schnitzel/hass-miner",
-  "requirements": ["minerinterface==0.5.2"],
+  "requirements": ["pyasic==0.19.1"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},
-  "dependencies": [],
   "codeowners": ["@Schnitzel"],
   "iot_class": "local_polling",
   "version": "0.6.0"

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -1,14 +1,14 @@
 {
   "domain": "miner",
   "name": "Miner",
-  "issue_tracker": "https://github.com/Schnitzel/hass-miner/issues",
+  "issue_tracker": "https://github.com/UpstreamData/hass-miner/issues",
   "config_flow": true,
-  "documentation": "https://github.com/Schnitzel/hass-miner",
+  "documentation": "https://github.com/UpstreamData/hass-miner",
   "requirements": ["pyasic==0.26.2"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},
-  "codeowners": ["@Schnitzel"],
+  "codeowners": ["@UpstreamData"],
   "iot_class": "local_polling",
   "version": "0.6.0"
 }

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,7 +4,7 @@
   "issue_tracker": "https://github.com/Schnitzel/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/Schnitzel/hass-miner",
-  "requirements": ["pyasic==0.19.1"],
+  "requirements": ["pyasic==0.20.2"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,7 +4,7 @@
   "issue_tracker": "https://github.com/Schnitzel/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/Schnitzel/hass-miner",
-  "requirements": ["pyasic==0.21.7"],
+  "requirements": ["pyasic==0.21.9"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,7 +4,7 @@
   "issue_tracker": "https://github.com/Schnitzel/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/Schnitzel/hass-miner",
-  "requirements": ["pyasic==0.21.2"],
+  "requirements": ["pyasic==0.21.3"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,11 +4,11 @@
   "issue_tracker": "https://github.com/UpstreamData/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/UpstreamData/hass-miner",
-  "requirements": ["pyasic==0.33.11"],
+  "requirements": ["pyasic==0.36.3"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},
   "codeowners": ["@UpstreamData"],
   "iot_class": "local_polling",
-  "version": "0.6.0"
+  "version": "0.7.0"
 }

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,7 +4,7 @@
   "issue_tracker": "https://github.com/Schnitzel/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/Schnitzel/hass-miner",
-  "requirements": ["pyasic==0.21.6"],
+  "requirements": ["pyasic==0.21.7"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,7 +4,7 @@
   "issue_tracker": "https://github.com/Schnitzel/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/Schnitzel/hass-miner",
-  "requirements": ["pyasic==0.21.3"],
+  "requirements": ["pyasic==0.21.4"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,7 +4,7 @@
   "issue_tracker": "https://github.com/UpstreamData/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/UpstreamData/hass-miner",
-  "requirements": ["pyasic==0.33.9"],
+  "requirements": ["pyasic==0.33.11"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,11 +4,11 @@
   "issue_tracker": "https://github.com/UpstreamData/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/UpstreamData/hass-miner",
-  "requirements": ["pyasic==0.32.3"],
+  "requirements": ["pyasic==0.32.9"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},
   "codeowners": ["@UpstreamData"],
   "iot_class": "local_polling",
-  "version": "0.7.0"
+  "version": "0.6.0"
 }

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,7 +4,7 @@
   "issue_tracker": "https://github.com/Schnitzel/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/Schnitzel/hass-miner",
-  "requirements": ["pyasic==0.21.5"],
+  "requirements": ["pyasic==0.21.6"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,7 +4,7 @@
   "issue_tracker": "https://github.com/Schnitzel/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/Schnitzel/hass-miner",
-  "requirements": ["pyasic==0.20.2"],
+  "requirements": ["pyasic==0.21.0"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,7 +4,7 @@
   "issue_tracker": "https://github.com/Schnitzel/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/Schnitzel/hass-miner",
-  "requirements": ["pyasic==0.21.10"],
+  "requirements": ["pyasic==0.26.2"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,7 +4,7 @@
   "issue_tracker": "https://github.com/Schnitzel/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/Schnitzel/hass-miner",
-  "requirements": ["pyasic==0.21.9"],
+  "requirements": ["pyasic==0.21.10"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,7 +4,7 @@
   "issue_tracker": "https://github.com/Schnitzel/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/Schnitzel/hass-miner",
-  "requirements": ["pyasic==0.21.0"],
+  "requirements": ["pyasic==0.21.1"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,7 +4,7 @@
   "issue_tracker": "https://github.com/Schnitzel/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/Schnitzel/hass-miner",
-  "requirements": ["pyasic==0.21.1"],
+  "requirements": ["pyasic==0.21.2"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,7 +4,7 @@
   "issue_tracker": "https://github.com/Schnitzel/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/Schnitzel/hass-miner",
-  "requirements": ["pyasic==0.21.4"],
+  "requirements": ["pyasic==0.21.5"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,7 +4,7 @@
   "issue_tracker": "https://github.com/UpstreamData/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/UpstreamData/hass-miner",
-  "requirements": ["pyasic==0.26.2"],
+  "requirements": ["pyasic==0.30.11"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -4,7 +4,7 @@
   "issue_tracker": "https://github.com/UpstreamData/hass-miner/issues",
   "config_flow": true,
   "documentation": "https://github.com/UpstreamData/hass-miner",
-  "requirements": ["pyasic==0.32.9"],
+  "requirements": ["pyasic==0.33.9"],
   "ssdp": [],
   "zeroconf": [],
   "homekit": {},

--- a/custom_components/miner/number.py
+++ b/custom_components/miner/number.py
@@ -54,6 +54,7 @@ async def async_setup_entry(
     # coordinator.async_add_listener(new_data_received)
 
 
+# TODO: This needs an update.  Lots of weird lint errors here.
 class MinerPowerLimitNumber(CoordinatorEntity[MinerCoordinator], NumberEntity):
     """Defines a Miner Number to set the Power Limit of the Miner"""
 

--- a/custom_components/miner/number.py
+++ b/custom_components/miner/number.py
@@ -93,7 +93,7 @@ class MinerPowerLimitNumber(CoordinatorEntity[MinerCoordinator], NumberEntity):
 
         miner = self.coordinator.miner
         if not miner.supports_autotuning:
-            raise TypeError("This miner does not support setting power limit.")
+            raise TypeError(f"{miner} does not support setting power limit.")
 
         result = await miner.set_power_limit(int(value))
         if not result:

--- a/custom_components/miner/number.py
+++ b/custom_components/miner/number.py
@@ -92,7 +92,7 @@ class MinerPowerLimitNumber(CoordinatorEntity[MinerCoordinator], NumberEntity):
         """Update the current value."""
 
         miner = self.coordinator.miner
-        if not miner.autotuning_enabled:
+        if not miner.supports_autotuning:
             raise TypeError("This miner does not support setting power limit.")
 
         result = await miner.set_power_limit(int(value))

--- a/custom_components/miner/number.py
+++ b/custom_components/miner/number.py
@@ -80,10 +80,10 @@ class MinerPowerLimitNumber(CoordinatorEntity[MinerCoordinator], NumberEntity):
     def device_info(self) -> entity.DeviceInfo:
         """Return device info."""
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.data["hostname"])},
-            manufacturer="Antminer",
+            identifiers={(DOMAIN, self.coordinator.data["mac"])},
+            manufacturer=self.coordinator.data["make"],
             model=self.coordinator.data["model"],
-            name=f"Antminer {self.coordinator.data['model']}",
+            name=f"{self.coordinator.data['make']} {self.coordinator.data['model']}",
         )
 
     async def async_set_value(self, value):

--- a/custom_components/miner/number.py
+++ b/custom_components/miner/number.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from pyasic.config import MinerConfig
 
 from .const import (
     DOMAIN,
@@ -92,10 +93,9 @@ class MinerPowerLimitNumber(CoordinatorEntity[MinerCoordinator], NumberEntity):
 
         miner = self.coordinator.miner
         await miner.get_config()
-        updated_config = yaml.load(miner.config, Loader=yaml.SafeLoader)
-        updated_config["autotuning"]["wattage"] = int(value)
-        config_yaml = yaml.dump(updated_config, sort_keys=False)
-        await miner.send_config(config_yaml)
+        updated_config = miner.config
+        updated_config.autotuning_wattage = int(value)
+        await miner.send_config(updated_config.as_yaml())
 
         self._attr_value = value
         self.async_write_ha_state()

--- a/custom_components/miner/number.py
+++ b/custom_components/miner/number.py
@@ -29,7 +29,7 @@ async def async_setup_entry(
     created = set()
 
     @callback
-    def _create_entity(key: str) -> NumberEntity:
+    def _create_entity(key: str):
         """Create a sensor entity."""
         created.add(key)
 

--- a/custom_components/miner/number.py
+++ b/custom_components/miner/number.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import logging
 
-import yaml
 from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
@@ -11,7 +10,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from pyasic.config import MinerConfig
 
 from .const import (
     DOMAIN,

--- a/custom_components/miner/sensor.py
+++ b/custom_components/miner/sensor.py
@@ -198,10 +198,10 @@ class MinerSensor(CoordinatorEntity[MinerCoordinator], SensorEntity):
     def device_info(self) -> entity.DeviceInfo:
         """Return device info."""
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.data["hostname"])},
-            manufacturer="Antminer",
+            identifiers={(DOMAIN, self.coordinator.data["mac"])},
+            manufacturer=self.coordinator.data["make"],
             model=self.coordinator.data["model"],
-            name=f"Antminer {self.coordinator.data['model']}",
+            name=f"{self.coordinator.data['make']} {self.coordinator.data['model']}",
         )
 
     @callback
@@ -256,10 +256,10 @@ class MinerBoardSensor(CoordinatorEntity[MinerCoordinator], SensorEntity):
     def device_info(self) -> entity.DeviceInfo:
         """Return device info."""
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.data["hostname"])},
-            manufacturer="Antminer",
+            identifiers={(DOMAIN, self.coordinator.data["mac"])},
+            manufacturer=self.coordinator.data["make"],
             model=self.coordinator.data["model"],
-            name=f"Antminer {self.coordinator.data['model']}",
+            name=f"{self.coordinator.data['make']} {self.coordinator.data['model']}",
         )
 
     @callback

--- a/custom_components/miner/sensor.py
+++ b/custom_components/miner/sensor.py
@@ -67,6 +67,12 @@ ENTITY_DESCRIPTION_KEY_MAP: dict[
         state_class=SensorStateClass.MEASUREMENT,
         device_class="Hashrate",
     ),
+    "ideal_hashrate": MinerSensorEntityDescription(
+        "Hashrate",
+        native_unit_of_measurement="TH/s",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class="Hashrate",
+    ),
     "board_hashrate": MinerSensorEntityDescription(
         "Board Hashrate",
         native_unit_of_measurement="TH/s",
@@ -81,12 +87,6 @@ ENTITY_DESCRIPTION_KEY_MAP: dict[
     ),
     "miner_consumption": MinerSensorEntityDescription(
         "Miner Consumption",
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=POWER_WATT,
-        device_class=SensorDeviceClass.POWER,
-    ),
-    "scaled_power_limit": MinerSensorEntityDescription(
-        "Scaled Power Limit",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=POWER_WATT,
         device_class=SensorDeviceClass.POWER,

--- a/custom_components/miner/sensor.py
+++ b/custom_components/miner/sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Union
 
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.sensor import SensorEntity
@@ -31,13 +32,13 @@ _LOGGER = logging.getLogger(__name__)
 class MinerSensorEntityDescription(SensorEntityDescription):
     """Class describing IotaWatt sensor entities."""
 
-    value: Callable | None = None
+    value: Union[Callable, None] = None
 
 
 class MinerNumberEntityDescription(SensorEntityDescription):
     """Class describing IotaWatt number entities."""
 
-    value: Callable | None = None
+    value: Union[Callable, None] = None
 
 
 ENTITY_DESCRIPTION_KEY_MAP: dict[
@@ -68,7 +69,7 @@ ENTITY_DESCRIPTION_KEY_MAP: dict[
         device_class="Hashrate",
     ),
     "ideal_hashrate": MinerSensorEntityDescription(
-        "Hashrate",
+        "Ideal Hashrate",
         native_unit_of_measurement="TH/s",
         state_class=SensorStateClass.MEASUREMENT,
         device_class="Hashrate",

--- a/custom_components/miner/switch.py
+++ b/custom_components/miner/switch.py
@@ -112,7 +112,7 @@ class MinerActiveSwitch(CoordinatorEntity[MinerCoordinator], SwitchEntity):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        is_mining = await self.coordinator.miner.is_mining()
+        is_mining = self.coordinator.data["is_mining"]
         if is_mining is not None:
             self._attr_is_on = is_mining
 

--- a/custom_components/miner/switch.py
+++ b/custom_components/miner/switch.py
@@ -85,10 +85,10 @@ class MinerActiveSwitch(CoordinatorEntity[MinerCoordinator], SwitchEntity):
     def device_info(self) -> entity.DeviceInfo:
         """Return device info."""
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.data["hostname"])},
-            manufacturer="Antminer",
+            identifiers={(DOMAIN, self.coordinator.data["mac"])},
+            manufacturer=self.coordinator.data["make"],
             model=self.coordinator.data["model"],
-            name=f"Antminer {self.coordinator.data['model']}",
+            name=f"{self.coordinator.data['make']} {self.coordinator.data['model']}",
         )
 
     async def async_turn_on(self) -> None:

--- a/custom_components/miner/switch.py
+++ b/custom_components/miner/switch.py
@@ -94,14 +94,20 @@ class MinerActiveSwitch(CoordinatorEntity[MinerCoordinator], SwitchEntity):
 
     async def async_turn_on(self) -> None:
         """Turn on miner."""
+        miner = self.coordinator.miner
+        if not miner.supports_autotuning:
+            raise TypeError(f"{miner} does not support shutdown mode.")
         self._attr_is_on = True
-        await self.coordinator.miner.api.resume()
+        await miner.resume_mining()
         self.async_write_ha_state()
 
     async def async_turn_off(self) -> None:
         """Turn off miner."""
+        miner = self.coordinator.miner
+        if not miner.supports_autotuning:
+            raise TypeError(f"{miner} does not support shutdown mode.")
         self._attr_is_on = False
-        await self.coordinator.miner.api.pause()
+        await miner.stop_mining()
         self.async_write_ha_state()
 
     @callback
@@ -109,6 +115,6 @@ class MinerActiveSwitch(CoordinatorEntity[MinerCoordinator], SwitchEntity):
 
         # There isn't really a good way to check if the Miner is on.
         # But when it's off there is no temperature reported, so we use this
-        self._attr_is_on = self.coordinator.data["miner_sensors"]["temperature"] != 0
+        self._attr_is_on = self.coordinator.data["miner_sensors"]["is_mining"]
 
         super()._handle_coordinator_update()

--- a/custom_components/miner/switch.py
+++ b/custom_components/miner/switch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Union
 
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.components.switch import SwitchEntity
@@ -26,7 +27,7 @@ _LOGGER = logging.getLogger(__name__)
 class MinerSensorEntityDescription(SensorEntityDescription):
     """Class describing IotaWatt sensor entities."""
 
-    value: Callable | None = None
+    value: Union[Callable, None] = None
 
 
 async def async_setup_entry(

--- a/custom_components/miner/switch.py
+++ b/custom_components/miner/switch.py
@@ -112,9 +112,8 @@ class MinerActiveSwitch(CoordinatorEntity[MinerCoordinator], SwitchEntity):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-
-        # There isn't really a good way to check if the Miner is on.
-        # But when it's off there is no temperature reported, so we use this
-        self._attr_is_on = self.coordinator.data["miner_sensors"]["is_mining"]
+        is_mining = await self.coordinator.miner.is_mining()
+        if is_mining is not None:
+            self._attr_is_on = is_mining
 
         super()._handle_coordinator_update()

--- a/custom_components/miner/switch.py
+++ b/custom_components/miner/switch.py
@@ -95,7 +95,7 @@ class MinerActiveSwitch(CoordinatorEntity[MinerCoordinator], SwitchEntity):
     async def async_turn_on(self) -> None:
         """Turn on miner."""
         miner = self.coordinator.miner
-        if not miner.supports_autotuning:
+        if not miner.supports_shutdown:
             raise TypeError(f"{miner} does not support shutdown mode.")
         self._attr_is_on = True
         await miner.resume_mining()
@@ -104,7 +104,7 @@ class MinerActiveSwitch(CoordinatorEntity[MinerCoordinator], SwitchEntity):
     async def async_turn_off(self) -> None:
         """Turn off miner."""
         miner = self.coordinator.miner
-        if not miner.supports_autotuning:
+        if not miner.supports_shutdown:
             raise TypeError(f"{miner} does not support shutdown mode.")
         self._attr_is_on = False
         await miner.stop_mining()

--- a/info.md
+++ b/info.md
@@ -43,8 +43,8 @@ Code template was mainly taken from [@Ludeeus](https://github.com/ludeeus)'s [in
 [integration_blueprint]: https://github.com/custom-components/integration_blueprint
 [buymecoffee]: https://www.buymeacoffee.com/ludeeus
 [buymecoffeebadge]: https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg?style=for-the-badge
-[commits-shield]: https://img.shields.io/github/commit-activity/y/Schnitzel/miner.svg?style=for-the-badge
-[commits]: https://github.com/Schnitzel/miner/commits/main
+[commits-shield]: https://img.shields.io/github/commit-activity/y/UpstreamData/miner.svg?style=for-the-badge
+[commits]: https://github.com/UpstreamData/miner/commits/main
 [hacs]: https://hacs.xyz
 [hacsbadge]: https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge
 [discord]: https://discord.gg/Qa5fW2R
@@ -52,9 +52,9 @@ Code template was mainly taken from [@Ludeeus](https://github.com/ludeeus)'s [in
 [exampleimg]: example.png
 [forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg?style=for-the-badge
 [forum]: https://community.home-assistant.io/
-[license]: https://github.com/Schnitzel/miner/blob/main/LICENSE
-[license-shield]: https://img.shields.io/github/license/Schnitzel/miner.svg?style=for-the-badge
-[maintenance-shield]: https://img.shields.io/badge/maintainer-%40Schnitzel-blue.svg?style=for-the-badge
-[releases-shield]: https://img.shields.io/github/release/Schnitzel/miner.svg?style=for-the-badge
-[releases]: https://github.com/Schnitzel/miner/releases
-[user_profile]: https://github.com/Schnitzel
+[license]: https://github.com/UpstreamData/miner/blob/main/LICENSE
+[license-shield]: https://img.shields.io/github/license/UpstreamData/miner.svg?style=for-the-badge
+[maintenance-shield]: https://img.shields.io/badge/maintainer-%40UpstreamData-blue.svg?style=for-the-badge
+[releases-shield]: https://img.shields.io/github/release/UpstreamData/miner.svg?style=for-the-badge
+[releases]: https://github.com/UpstreamData/miner/releases
+[user_profile]: https://github.com/UpstreamData

--- a/info.md
+++ b/info.md
@@ -9,12 +9,12 @@
 [![Discord][discord-shield]][discord]
 [![Community Forum][forum-shield]][forum]
 
-**This component will set up the following platforms.**
+**This component will set up the following platforms -**
 
 | Platform        | Description                         |
-| --------------- | ----------------------------------- |
+| --------------- |-------------------------------------|
 | `binary_sensor` | Show something `True` or `False`.   |
-| `sensor`        | Show info from API.                 |
+| `sensor`        | Show miner sensor info.             |
 | `switch`        | Switch something `True` or `False`. |
 
 ![example][exampleimg]
@@ -24,7 +24,7 @@
 ## Installation
 
 1. Click install.
-1. In the HA UI go to "Configuration" -> "Integrations" click "+" and search for "miner".
+2. In the HA UI go to "Configuration" -> "Integrations" click "+" and search for "miner".
 
 {% endif %}
 
@@ -36,7 +36,9 @@
 
 This project was generated from [@oncleben31](https://github.com/oncleben31)'s [Home Assistant Custom Component Cookiecutter](https://github.com/oncleben31/cookiecutter-homeassistant-custom-component) template.
 
-Code template was mainly taken from [@Ludeeus](https://github.com/ludeeus)'s [integration_blueprint][integration_blueprint] template
+Code template was mainly taken from [@Ludeeus](https://github.com/ludeeus)'s [integration_blueprint][integration_blueprint] template.
+
+Miner control and data is handled using [@UpstreamData](https://github.com/UpstreamData)'s [pyasic](https://github.com/UpstreamData/pyasic).
 
 ---
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,2 @@
 homeassistant
-minerinterface==0.5.3
+pyasic

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,88 +1,88 @@
-"""Tests for miner api."""
-import asyncio
-
-import aiohttp
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-
-from custom_components.miner.api import (
-    MinerApiClient,
-)
-
-
-async def test_api(hass, aioclient_mock, caplog):
-    """Test API calls."""
-
-    # To test the api submodule, we first create an instance of our API client
-    api = MinerApiClient("test", "test", async_get_clientsession(hass))
-
-    # Use aioclient_mock which is provided by `pytest_homeassistant_custom_components`
-    # to mock responses to aiohttp requests. In this case we are telling the mock to
-    # return {"test": "test"} when a `GET` call is made to the specified URL. We then
-    # call `async_get_data` which will make that `GET` request.
-    aioclient_mock.get(
-        "https://jsonplaceholder.typicode.com/posts/1", json={"test": "test"}
-    )
-    assert await api.async_get_data() == {"test": "test"}
-
-    # We do the same for `async_set_title`. Note the difference in the mock call
-    # between the previous step and this one. We use `patch` here instead of `get`
-    # because we know that `async_set_title` calls `api_wrapper` with `patch` as the
-    # first parameter
-    aioclient_mock.patch("https://jsonplaceholder.typicode.com/posts/1")
-    assert await api.async_set_title("test") is None
-
-    # In order to get 100% coverage, we need to test `api_wrapper` to test the code
-    # that isn't already called by `async_get_data` and `async_set_title`. Because the
-    # only logic that lives inside `api_wrapper` that is not being handled by a third
-    # party library (aiohttp) is the exception handling, we also want to simulate
-    # raising the exceptions to ensure that the function handles them as expected.
-    # The caplog fixture allows access to log messages in tests. This is particularly
-    # useful during exception handling testing since often the only action as part of
-    # exception handling is a logging statement
-    caplog.clear()
-    aioclient_mock.put(
-        "https://jsonplaceholder.typicode.com/posts/1", exc=asyncio.TimeoutError
-    )
-    assert (
-        await api.api_wrapper("put", "https://jsonplaceholder.typicode.com/posts/1")
-        is None
-    )
-    assert (
-        len(caplog.record_tuples) == 1
-        and "Timeout error fetching information from" in caplog.record_tuples[0][2]
-    )
-
-    caplog.clear()
-    aioclient_mock.post(
-        "https://jsonplaceholder.typicode.com/posts/1", exc=aiohttp.ClientError
-    )
-    assert (
-        await api.api_wrapper("post", "https://jsonplaceholder.typicode.com/posts/1")
-        is None
-    )
-    assert (
-        len(caplog.record_tuples) == 1
-        and "Error fetching information from" in caplog.record_tuples[0][2]
-    )
-
-    caplog.clear()
-    aioclient_mock.post("https://jsonplaceholder.typicode.com/posts/2", exc=Exception)
-    assert (
-        await api.api_wrapper("post", "https://jsonplaceholder.typicode.com/posts/2")
-        is None
-    )
-    assert (
-        len(caplog.record_tuples) == 1
-        and "Something really wrong happened!" in caplog.record_tuples[0][2]
-    )
-
-    caplog.clear()
-    aioclient_mock.post("https://jsonplaceholder.typicode.com/posts/3", exc=TypeError)
-    assert (
-        await api.api_wrapper("post", "https://jsonplaceholder.typicode.com/posts/3")
-        is None
-    )
-    assert (
-        len(caplog.record_tuples) == 1
-        and "Error parsing information from" in caplog.record_tuples[0][2]
-    )
+# """Tests for miner api."""
+# import asyncio
+#
+# import aiohttp
+# from homeassistant.helpers.aiohttp_client import async_get_clientsession
+#
+# from custom_components.miner.api import (
+#     MinerApiClient,
+# )
+#
+#
+# async def test_api(hass, aioclient_mock, caplog):
+#     """Test API calls."""
+#
+#     # To test the api submodule, we first create an instance of our API client
+#     api = MinerApiClient("test", "test", async_get_clientsession(hass))
+#
+#     # Use aioclient_mock which is provided by `pytest_homeassistant_custom_components`
+#     # to mock responses to aiohttp requests. In this case we are telling the mock to
+#     # return {"test": "test"} when a `GET` call is made to the specified URL. We then
+#     # call `async_get_data` which will make that `GET` request.
+#     aioclient_mock.get(
+#         "https://jsonplaceholder.typicode.com/posts/1", json={"test": "test"}
+#     )
+#     assert await api.async_get_data() == {"test": "test"}
+#
+#     # We do the same for `async_set_title`. Note the difference in the mock call
+#     # between the previous step and this one. We use `patch` here instead of `get`
+#     # because we know that `async_set_title` calls `api_wrapper` with `patch` as the
+#     # first parameter
+#     aioclient_mock.patch("https://jsonplaceholder.typicode.com/posts/1")
+#     assert await api.async_set_title("test") is None
+#
+#     # In order to get 100% coverage, we need to test `api_wrapper` to test the code
+#     # that isn't already called by `async_get_data` and `async_set_title`. Because the
+#     # only logic that lives inside `api_wrapper` that is not being handled by a third
+#     # party library (aiohttp) is the exception handling, we also want to simulate
+#     # raising the exceptions to ensure that the function handles them as expected.
+#     # The caplog fixture allows access to log messages in tests. This is particularly
+#     # useful during exception handling testing since often the only action as part of
+#     # exception handling is a logging statement
+#     caplog.clear()
+#     aioclient_mock.put(
+#         "https://jsonplaceholder.typicode.com/posts/1", exc=asyncio.TimeoutError
+#     )
+#     assert (
+#         await api.api_wrapper("put", "https://jsonplaceholder.typicode.com/posts/1")
+#         is None
+#     )
+#     assert (
+#         len(caplog.record_tuples) == 1
+#         and "Timeout error fetching information from" in caplog.record_tuples[0][2]
+#     )
+#
+#     caplog.clear()
+#     aioclient_mock.post(
+#         "https://jsonplaceholder.typicode.com/posts/1", exc=aiohttp.ClientError
+#     )
+#     assert (
+#         await api.api_wrapper("post", "https://jsonplaceholder.typicode.com/posts/1")
+#         is None
+#     )
+#     assert (
+#         len(caplog.record_tuples) == 1
+#         and "Error fetching information from" in caplog.record_tuples[0][2]
+#     )
+#
+#     caplog.clear()
+#     aioclient_mock.post("https://jsonplaceholder.typicode.com/posts/2", exc=Exception)
+#     assert (
+#         await api.api_wrapper("post", "https://jsonplaceholder.typicode.com/posts/2")
+#         is None
+#     )
+#     assert (
+#         len(caplog.record_tuples) == 1
+#         and "Something really wrong happened!" in caplog.record_tuples[0][2]
+#     )
+#
+#     caplog.clear()
+#     aioclient_mock.post("https://jsonplaceholder.typicode.com/posts/3", exc=TypeError)
+#     assert (
+#         await api.api_wrapper("post", "https://jsonplaceholder.typicode.com/posts/3")
+#         is None
+#     )
+#     assert (
+#         len(caplog.record_tuples) == 1
+#         and "Error parsing information from" in caplog.record_tuples[0][2]
+#     )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,16 +5,13 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from .const import MOCK_CONFIG
 from custom_components.miner import (
-    async_reload_entry,
-)
-from custom_components.miner import (
     async_setup_entry,
 )
 from custom_components.miner import (
     async_unload_entry,
 )
 from custom_components.miner import (
-    MinerDataUpdateCoordinator,
+    MinerCoordinator,
 )
 from custom_components.miner.const import (
     DOMAIN,
@@ -36,12 +33,12 @@ async def test_setup_unload_and_reload_entry(hass, bypass_get_data):
     # call, no code from custom_components/miner/api.py actually runs.
     assert await async_setup_entry(hass, config_entry)
     assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
-    assert type(hass.data[DOMAIN][config_entry.entry_id]) == MinerDataUpdateCoordinator
+    assert type(hass.data[DOMAIN][config_entry.entry_id]) == MinerCoordinator
 
     # Reload the entry and assert that the data from above is still there
-    assert await async_reload_entry(hass, config_entry) is None
+    # assert await async_reload_entry(hass, config_entry) is None
     assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
-    assert type(hass.data[DOMAIN][config_entry.entry_id]) == MinerDataUpdateCoordinator
+    assert type(hass.data[DOMAIN][config_entry.entry_id]) == MinerCoordinator
 
     # Unload the entry and verify that the data has been removed
     assert await async_unload_entry(hass, config_entry)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -11,43 +11,43 @@ from .const import MOCK_CONFIG
 from custom_components.miner import (
     async_setup_entry,
 )
-from custom_components.miner.const import (
-    DEFAULT_NAME,
-)
-from custom_components.miner.const import (
-    DOMAIN,
-)
-from custom_components.miner.const import (
-    SWITCH,
-)
-
-
-async def test_switch_services(hass):
-    """Test switch services."""
-    # Create a mock entry so we don't have to go through config flow
-    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
-    assert await async_setup_entry(hass, config_entry)
-    await hass.async_block_till_done()
-
-    # Functions/objects can be patched directly in test code as well and can be used to test
-    # additional things, like whether a function was called or what arguments it was called with
-    with patch("custom_components.miner.MinerApiClient.async_set_title") as title_func:
-        await hass.services.async_call(
-            SWITCH,
-            SERVICE_TURN_OFF,
-            service_data={ATTR_ENTITY_ID: f"{SWITCH}.{DEFAULT_NAME}_{SWITCH}"},
-            blocking=True,
-        )
-        assert title_func.called
-        assert title_func.call_args == call("foo")
-
-        title_func.reset_mock()
-
-        await hass.services.async_call(
-            SWITCH,
-            SERVICE_TURN_ON,
-            service_data={ATTR_ENTITY_ID: f"{SWITCH}.{DEFAULT_NAME}_{SWITCH}"},
-            blocking=True,
-        )
-        assert title_func.called
-        assert title_func.call_args == call("bar")
+# from custom_components.miner.const import (
+#     DEFAULT_NAME,
+# )
+# from custom_components.miner.const import (
+#     DOMAIN,
+# )
+# from custom_components.miner.const import (
+#     SWITCH,
+# )
+#
+#
+# async def test_switch_services(hass):
+#     """Test switch services."""
+#     # Create a mock entry so we don't have to go through config flow
+#     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+#     assert await async_setup_entry(hass, config_entry)
+#     await hass.async_block_till_done()
+#
+#     # Functions/objects can be patched directly in test code as well and can be used to test
+#     # additional things, like whether a function was called or what arguments it was called with
+#     with patch("custom_components.miner.MinerApiClient.async_set_title") as title_func:
+#         await hass.services.async_call(
+#             SWITCH,
+#             SERVICE_TURN_OFF,
+#             service_data={ATTR_ENTITY_ID: f"{SWITCH}.{DEFAULT_NAME}_{SWITCH}"},
+#             blocking=True,
+#         )
+#         assert title_func.called
+#         assert title_func.call_args == call("foo")
+#
+#         title_func.reset_mock()
+#
+#         await hass.services.async_call(
+#             SWITCH,
+#             SERVICE_TURN_ON,
+#             service_data={ATTR_ENTITY_ID: f"{SWITCH}.{DEFAULT_NAME}_{SWITCH}"},
+#             blocking=True,
+#         )
+#         assert title_func.called
+#         assert title_func.call_args == call("bar")


### PR DESCRIPTION
Updated all usages of the forked version of minerInterface to be pyasic instead, and updated data functionality to match.

Updated usages of MinerFactory to be more concise, MinerFactory is a Singleton, so it can just be called by doing `MinerFactory().get_miner()` instead of having to declare an instance.