### PR TITLE
Remove NumberEntity deprecated functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Control your Bitcoin miner from Home Assistant.
 
 ## Installation
 
-Use HACS, add the custom repo https://github.com/UpstreamData/hass-miner to it
+Use HACS, add the custom repo https://github.com/Schnitzel/hass-miner to it
 
 Installation and usage:
 

--- a/custom_components/miner/config_flow.py
+++ b/custom_components/miner/config_flow.py
@@ -42,7 +42,8 @@ async def validate_input(data: dict[str, str]) -> dict[str, str]:
         miner.pwd = miner_password
         await miner.get_data()
 
-    except Exception:  # pylint: disable=broad-except
+    except Exception as e:  # pylint: disable=broad-except
+        _LOGGER.error(f"Miner setup error: {e}")
         return {
             "base": "Unable to authenticate with Miner, is Username & Password correct?"
         }

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -74,7 +74,7 @@ class MinerCoordinator(DataUpdateCoordinator):
             "miner_sensors": {
                 "hashrate": miner_data.hashrate,
                 "ideal_hashrate": miner_data.nominal_hashrate,
-                "temperature": int(miner_data.temperature_avg),
+                "temperature": miner_data.temperature_avg,
                 "power_limit": miner_data.wattage_limit,
                 "miner_consumption": miner_data.wattage,
             },

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -7,7 +7,7 @@
   "homekit": {},
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Schnitzel/hass-miner/issues",
-  "requirements": ["pyasic==0.37.7"],
+  "requirements": ["pyasic==0.37.8"],
   "ssdp": [],
   "version": "0.7.0",
   "zeroconf": []

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -7,7 +7,7 @@
   "homekit": {},
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Schnitzel/hass-miner/issues",
-  "requirements": ["pyasic==0.37.6"],
+  "requirements": ["pyasic==0.37.7"],
   "ssdp": [],
   "version": "0.7.0",
   "zeroconf": []

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -7,7 +7,7 @@
   "homekit": {},
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Schnitzel/hass-miner/issues",
-  "requirements": ["pyasic==0.36.9"],
+  "requirements": ["pyasic==0.37.6"],
   "ssdp": [],
   "version": "0.7.0",
   "zeroconf": []

--- a/custom_components/miner/manifest.json
+++ b/custom_components/miner/manifest.json
@@ -7,7 +7,7 @@
   "homekit": {},
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Schnitzel/hass-miner/issues",
-  "requirements": ["pyasic==0.37.8"],
+  "requirements": ["pyasic==0.40.0"],
   "ssdp": [],
   "version": "0.7.0",
   "zeroconf": []

--- a/custom_components/miner/number.py
+++ b/custom_components/miner/number.py
@@ -55,23 +55,13 @@ async def async_setup_entry(
     # coordinator.async_add_listener(new_data_received)
 
 
-# TODO: This needs an update.  Lots of weird lint errors here.
 class MinerPowerLimitNumber(CoordinatorEntity[MinerCoordinator], NumberEntity):
     """Defines a Miner Number to set the Power Limit of the Miner."""
 
-    def __init__(
-        self,
-        coordinator: MinerCoordinator,
-    ) -> None:
-        """Initialize the sensor."""
+    def __init__(self, coordinator: MinerCoordinator):
+        """Initialize the PowerLimit entity."""
         super().__init__(coordinator=coordinator)
-        self._attr_unique_id = f"{self.coordinator.data['mac']}-power_limit"
-
-        self._attr_value = self.coordinator.data["miner_sensors"]["power_limit"]
-
-        self._attr_min_value = 100
-        self._attr_max_value = 5000
-        self._attr_step = 100
+        self._attr_native_value = self.coordinator.data["miner_sensors"]["power_limit"]
 
     @property
     def name(self) -> str | None:
@@ -89,7 +79,32 @@ class MinerPowerLimitNumber(CoordinatorEntity[MinerCoordinator], NumberEntity):
             name=f"{self.coordinator.entry.title}",
         )
 
-    async def async_set_value(self, value):
+    @property
+    def unique_id(self) -> str | None:
+        """Return device UUID."""
+        return f"{self.coordinator.data['mac']}-power_limit"
+
+    @property
+    def native_min_value(self) -> float | None:
+        """Return device minimum value."""
+        return 100
+
+    @property
+    def native_max_value(self) -> float | None:
+        """Return device maximum value."""
+        return 5000
+
+    @property
+    def native_step(self) -> float | None:
+        """Return device increment step."""
+        return 100
+
+    @property
+    def native_unit_of_measurement(self):
+        """Return device unit of measurement."""
+        return "W"
+
+    async def async_set_native_value(self, value):
         """Update the current value."""
 
         miner = self.coordinator.miner
@@ -107,11 +122,11 @@ class MinerPowerLimitNumber(CoordinatorEntity[MinerCoordinator], NumberEntity):
         if not result:
             raise pyasic.APIError("Failed to set wattage.")
 
-        self._attr_value = value
+        self._attr_native_value = value
         self.async_write_ha_state()
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        self._attr_value = self.coordinator.data["miner_sensors"]["power_limit"]
+        self._attr_native_value = self.coordinator.data["miner_sensors"]["power_limit"]
 
         super()._handle_coordinator_update()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-minerinterface==0.5.3
 colorlog==6.7.0
-homeassistant==2023.7.1
+homeassistant
 pip>=21.0,<23.2
 ruff==0.0.267
-pyasic==0.36.9
+pyasic
 pre-commit


### PR DESCRIPTION
Updated the `MinerPowerLimitNumber` to use modern functionality of properties for storing info.  `native_value` is already implemented by the base `NumberEntity`, and returns `self._attr_native_value`, so that is used to hold the value and update the value of the entity.