### PR TITLE
Configure min and max power level values

### DIFF
--- a/custom_components/miner/config_flow.py
+++ b/custom_components/miner/config_flow.py
@@ -27,6 +27,8 @@ from homeassistant.helpers.selector import TextSelectorConfig
 from homeassistant.helpers.selector import TextSelectorType
 
 from .const import CONF_IP
+from .const import CONF_MIN_POWER
+from .const import CONF_MAX_POWER
 from .const import CONF_RPC_PASSWORD
 from .const import CONF_SSH_PASSWORD
 from .const import CONF_SSH_USERNAME
@@ -85,7 +87,15 @@ class MinerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             user_input = {}
 
         schema = vol.Schema(
-            {vol.Required(CONF_IP, default=user_input.get(CONF_IP, "")): str}
+            {
+                vol.Required(CONF_IP, default=user_input.get(CONF_IP, "")): str,
+                vol.Optional(CONF_MIN_POWER, default=100): vol.All(
+                    vol.Coerce(int), vol.Range(min=100, max=10000)
+                ),
+                vol.Optional(CONF_MAX_POWER, default=10000): vol.All(
+                    vol.Coerce(int), vol.Range(min=100, max=10000)
+                ),
+            }
         )
 
         if not user_input:

--- a/custom_components/miner/const.py
+++ b/custom_components/miner/const.py
@@ -9,6 +9,8 @@ CONF_SSH_USERNAME = "ssh_username"
 CONF_RPC_PASSWORD = "rpc_password"
 CONF_WEB_PASSWORD = "web_password"
 CONF_WEB_USERNAME = "web_username"
+CONF_MIN_POWER = "min_power"
+CONF_MAX_POWER = "max_power"
 
 SERVICE_REBOOT = "reboot"
 SERVICE_RESTART_BACKEND = "restart_backend"

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -23,6 +23,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .const import CONF_IP
+from .const import CONF_MIN_POWER
+from .const import CONF_MAX_POWER
 from .const import CONF_RPC_PASSWORD
 from .const import CONF_SSH_PASSWORD
 from .const import CONF_SSH_USERNAME
@@ -153,5 +155,9 @@ class MinerCoordinator(DataUpdateCoordinator):
                 idx: {"fan_speed": fan.speed} for idx, fan in enumerate(miner_data.fans)
             },
             "config": miner_data.config,
+            "power_limit_range": {
+                "min": self.config_entry.data.get(CONF_MIN_POWER, 100),
+                "max": self.config_entry.data.get(CONF_MAX_POWER, 10000),
+            },
         }
         return data

--- a/custom_components/miner/number.py
+++ b/custom_components/miner/number.py
@@ -105,12 +105,12 @@ class MinerPowerLimitNumber(CoordinatorEntity[MinerCoordinator], NumberEntity):
     @property
     def native_min_value(self) -> float | None:
         """Return device minimum value."""
-        return 100
+        return self.coordinator.data["power_limit_range"]["min"]
 
     @property
     def native_max_value(self) -> float | None:
         """Return device maximum value."""
-        return 10000
+        return self.coordinator.data["power_limit_range"]["max"]
 
     @property
     def native_step(self) -> float | None:

--- a/custom_components/miner/strings.json
+++ b/custom_components/miner/strings.json
@@ -4,7 +4,9 @@
     "step": {
       "user": {
         "data": {
-          "ip": "[%key:common::config_flow::data::ip%]"
+          "ip": "[%key:common::config_flow::data::ip%]",
+          "min_power": "[%key:common::config_flow::data::min_power%]",
+          "max_power": "[%key:common::config_flow::data::max_power%]"
         }
       },
       "login": {

--- a/custom_components/miner/translations/en.json
+++ b/custom_components/miner/translations/en.json
@@ -4,7 +4,9 @@
     "step": {
       "user": {
         "data": {
-          "ip": "IP Address"
+          "ip": "IP Address",
+          "min_power": "Min Power (W)",
+          "max_power": "Max Power (W)"
         }
       },
       "login": {


### PR DESCRIPTION
Currently, the min and max power levels are hard coded to 100 and 10,000. This PR aims to make the values configurable during the setup process of a new miner. This enables the range slider to be more accurate and prevents the user from accidentally setting a value that's too high for their hardware.

Btw, I'm still new to HA development, so not sure if this follows best practices, but it works™. Open to any feedback.