### PR TITLE
feat: offline resilience — load entry from a cached device profile when the miner is unreachable at startup

### DIFF
--- a/custom_components/miner/__init__.py
+++ b/custom_components/miner/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import DOMAIN
 from .coordinator import MinerCoordinator
@@ -23,10 +24,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = MinerCoordinator(
         hass,
         ip=entry.data[CONF_HOST],
+        entry_id=entry.entry_id,
         username=entry.data.get(CONF_USERNAME),
         password=entry.data.get(CONF_PASSWORD),
     )
-    await coordinator.async_config_entry_first_refresh()
+
+    # Offline resilience: load any cached device profile first, then attempt a
+    # refresh. Unlike async_config_entry_first_refresh(), a failed refresh does
+    # not abort setup as long as we have *something* to build entities from
+    # (live data or a cached profile) — the entry loads with entities showing
+    # ``unavailable`` and re-populates once the miner answers. Only raise
+    # ConfigEntryNotReady when we have neither a successful poll nor a cache.
+    await coordinator.async_load_profile()
+    await coordinator.async_refresh()
+    if (
+        not coordinator.last_update_success
+        and coordinator.profile is None
+        and coordinator.data is None
+    ):
+        raise ConfigEntryNotReady(
+            f"Could not reach miner at {entry.data[CONF_HOST]} and no cached "
+            "device profile is available yet"
+        )
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/miner/button.py
+++ b/custom_components/miner/button.py
@@ -35,7 +35,11 @@ async def async_setup_entry(
 
     entities: list[MinerEntity] = []
 
-    if coordinator.miner.supports_restart:
+    # coordinator.miner is None when the miner was unreachable at startup (the
+    # entry still loads for offline resilience). Capability-gated entities can't
+    # be probed without a connection, so they're skipped here and appear after
+    # the first successful connection + a reload.
+    if coordinator.miner is not None and coordinator.miner.supports_restart:
         entities.append(RestartButton(coordinator))
 
     async_add_entities(entities)

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -6,6 +6,7 @@ import logging
 from datetime import timedelta
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from pyasic_rs import MinerFactory
@@ -26,6 +27,7 @@ class MinerCoordinator(DataUpdateCoordinator[MinerData]):
         self,
         hass: HomeAssistant,
         ip: str,
+        entry_id: str,
         username: str | None = None,
         password: str | None = None,
     ) -> None:
@@ -33,12 +35,116 @@ class MinerCoordinator(DataUpdateCoordinator[MinerData]):
         self.username = username
         self.password = password
 
+        # ── Offline resilience: cached device profile ──────────────────────
+        # Persisted via Store (NOT entry.data — writing entry.data would trigger
+        # the options update listener and a reload-loop). Lets the entry LOAD
+        # with entities (showing unavailable) even when the miner is unreachable
+        # at HA startup. Populated from a successful poll; read as a fallback
+        # when live ``data`` is None.
+        self._store: Store = Store(hass, 1, f"{DOMAIN}_profile_{entry_id}")
+        self.profile: dict | None = None
+
         super().__init__(
             hass,
             _LOGGER,
             name=f"{DOMAIN}_{ip}",
             update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
         )
+
+    # ── Cached device profile (offline resilience) ─────────────────────────
+
+    async def async_load_profile(self) -> None:
+        """Load the persisted device profile (None if no file exists yet).
+
+        Called from __init__.py before the first refresh so that platforms can
+        enumerate per-board / per-fan entities from cache when the miner is
+        offline at startup.
+        """
+        self.profile = await self._store.async_load()
+
+    async def _async_store_profile(self, data: MinerData) -> None:
+        """Persist a fresh profile derived from a successful poll, if changed."""
+        profile = {
+            "mac": data.mac,
+            "make": data.device_info.make,
+            "model": data.device_info.model,
+            "fw": data.firmware_version,
+            "board_positions": [b.position for b in data.hashboards],
+            "fan_positions": [f.position for f in data.fans],
+            "psu_fan_positions": [f.position for f in data.psu_fans],
+        }
+        if profile != self.profile:
+            self.profile = profile
+            await self._store.async_save(profile)
+
+    # Helper properties: prefer live ``data``, fall back to the cached profile,
+    # finally a safe default. Used by entity.py and the platform setups so they
+    # work identically online and offline-with-cache.
+
+    @property
+    def device_mac(self) -> str | None:
+        data = self.data
+        if data is not None and data.mac:
+            return data.mac
+        if self.profile:
+            return self.profile.get("mac")
+        return None
+
+    @property
+    def device_make(self) -> str | None:
+        data = self.data
+        if data is not None and data.device_info.make:
+            return data.device_info.make
+        if self.profile:
+            return self.profile.get("make")
+        return None
+
+    @property
+    def device_model(self) -> str | None:
+        data = self.data
+        if data is not None and data.device_info.model:
+            return data.device_info.model
+        if self.profile:
+            return self.profile.get("model")
+        return None
+
+    @property
+    def fw_version(self) -> str | None:
+        data = self.data
+        if data is not None and data.firmware_version:
+            return data.firmware_version
+        if self.profile:
+            return self.profile.get("fw")
+        return None
+
+    @property
+    def board_positions(self) -> list[int]:
+        data = self.data
+        if data is not None:
+            return [b.position for b in data.hashboards]
+        if self.profile:
+            return list(self.profile.get("board_positions") or [])
+        return []
+
+    @property
+    def fan_positions(self) -> list[int]:
+        data = self.data
+        if data is not None:
+            return [f.position for f in data.fans]
+        if self.profile:
+            return list(self.profile.get("fan_positions") or [])
+        return []
+
+    @property
+    def psu_fan_positions(self) -> list[int]:
+        data = self.data
+        if data is not None:
+            return [f.position for f in data.psu_fans]
+        if self.profile:
+            return list(self.profile.get("psu_fan_positions") or [])
+        return []
+
+    # ── Setup / update ─────────────────────────────────────────────────────
 
     async def _async_setup(self) -> None:
         factory = MinerFactory()
@@ -53,8 +159,12 @@ class MinerCoordinator(DataUpdateCoordinator[MinerData]):
         if self.miner is None:
             await self._async_setup()
         try:
-            return await self.miner.get_data()
+            data = await self.miner.get_data()
         except Exception as err:
             raise UpdateFailed(
                 f"Error communicating with miner at {self.ip}: {err}"
             ) from err
+
+        # Persist a fresh device profile so the entry can load offline next time.
+        await self._async_store_profile(data)
+        return data

--- a/custom_components/miner/entity.py
+++ b/custom_components/miner/entity.py
@@ -17,21 +17,32 @@ class MinerEntity(CoordinatorEntity[MinerCoordinator]):
 
     def __init__(self, coordinator: MinerCoordinator) -> None:
         super().__init__(coordinator)
-        data = coordinator.data
+        # Build device info from the coordinator helpers (live data first, then
+        # cached profile, then None) so the device exists even when the miner is
+        # unreachable at startup. Tolerate all-None: never raise here.
+        mac = coordinator.device_mac
+        make = coordinator.device_make
+        model = coordinator.device_model
+        if make or model:
+            name = " ".join(p for p in (make, model) if p)
+        else:
+            name = f"ASIC Miner ({coordinator.ip})"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._device_unique_id)},
-            connections={(dr.CONNECTION_NETWORK_MAC, data.mac)} if data.mac else set(),
-            name=f"{data.device_info.make} {data.device_info.model}",
-            manufacturer=data.device_info.make,
-            model=data.device_info.model,
-            sw_version=data.firmware_version,
+            connections=(
+                {(dr.CONNECTION_NETWORK_MAC, mac)} if mac else set()
+            ),
+            name=name,
+            manufacturer=make,
+            model=model,
+            sw_version=coordinator.fw_version,
             configuration_url=f"http://{coordinator.ip}",
         )
 
     @property
     def _device_unique_id(self) -> str:
         """Stable device identifier: prefer MAC over IP."""
-        data = self.coordinator.data
-        if data and data.mac:
-            return data.mac.replace(":", "").lower()
+        mac = self.coordinator.device_mac
+        if mac:
+            return mac.replace(":", "").lower()
         return self.coordinator.ip

--- a/custom_components/miner/number.py
+++ b/custom_components/miner/number.py
@@ -53,7 +53,11 @@ async def async_setup_entry(
 
     entities: list[MinerEntity] = []
 
-    if coordinator.miner.supports_set_power_limit:
+    # coordinator.miner is None when the miner was unreachable at startup (the
+    # entry still loads for offline resilience). Capability-gated entities can't
+    # be probed without a connection, so they're skipped here and appear after
+    # the first successful connection + a reload.
+    if coordinator.miner is not None and coordinator.miner.supports_set_power_limit:
         entities.append(PowerLimitNumber(coordinator))
 
     async_add_entities(entities)

--- a/custom_components/miner/sensor.py
+++ b/custom_components/miner/sensor.py
@@ -179,8 +179,8 @@ def _primary_pool_url(data: MinerData) -> str | None:
 # ── Per-board sensor factories ──────────────────────────────────────────────
 
 
-def _board_sensors(board: BoardData) -> list[MinerSensorEntityDescription]:
-    n = board.position
+def _board_sensors(position: int) -> list[MinerSensorEntityDescription]:
+    n = position
     return [
         MinerSensorEntityDescription(
             key=f"board_{n}_hashrate",
@@ -348,20 +348,22 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: MinerCoordinator = hass.data[DOMAIN][entry.entry_id]
-    data = coordinator.data
 
     descriptions: list[MinerSensorEntityDescription] = list(MINER_SENSORS)
 
-    # Add per-board sensors for each detected hashboard
-    for board in data.hashboards:
-        descriptions.extend(_board_sensors(board))
+    # Enumerate per-board / per-fan entities from the coordinator helpers (live
+    # data first, then the cached profile). This way entities are still created
+    # from the cached profile when ``data`` is None (miner offline at startup);
+    # value_fns look the board/fan up by position at value time as before.
+    for position in coordinator.board_positions:
+        descriptions.extend(_board_sensors(position))
 
     # Add fan sensors
-    for fan in data.fans:
-        descriptions.append(_fan_sensor(fan.position, psu=False))
+    for position in coordinator.fan_positions:
+        descriptions.append(_fan_sensor(position, psu=False))
 
     # Add PSU fan sensors
-    for fan in data.psu_fans:
-        descriptions.append(_fan_sensor(fan.position, psu=True))
+    for position in coordinator.psu_fan_positions:
+        descriptions.append(_fan_sensor(position, psu=True))
 
     async_add_entities(MinerSensorEntity(coordinator, desc) for desc in descriptions)

--- a/custom_components/miner/switch.py
+++ b/custom_components/miner/switch.py
@@ -82,10 +82,14 @@ async def async_setup_entry(
 
     entities: list[MinerEntity] = []
 
-    if miner.supports_set_fault_light:
+    # miner is None when it was unreachable at startup (the entry still loads for
+    # offline resilience). Capability-gated entities can't be probed without a
+    # connection, so they're skipped and appear after the first successful
+    # connection + a reload.
+    if miner is not None and miner.supports_set_fault_light:
         entities.append(FaultLightSwitch(coordinator))
 
-    if miner.supports_pause and miner.supports_resume:
+    if miner is not None and miner.supports_pause and miner.supports_resume:
         entities.append(MiningSwitch(coordinator))
 
     async_add_entities(entities)


### PR DESCRIPTION
## What & why

Miners that are powered down — mine are PV/battery-driven and get switched off automatically through the day — currently leave the config entry in `setup_retry` with no entities until they come back. This makes the entry load from a small cached device profile, so the entities still exist (showing `unavailable`) and re-populate once the miner answers. Same idea as tntvlad/hass-miner#31 / #36, ported to this rewrite.

## How

- The coordinator persists a small profile (mac, make/model, firmware, board + fan positions) via `Store` after each successful poll.
- On setup it loads that cache, does a non-raising `async_refresh()`, and only raises `ConfigEntryNotReady` when there's neither a successful poll nor a cached profile — so a brand-new, never-seen miner that's offline at first setup still behaves exactly as before.
- `device_info` and the per-board / per-fan entity enumeration are built from live data with the cached profile as a fallback.

## Validated

On real hardware (S19 Pro Hydro / VNish + S19K Pro / BraiinsOS): powering the miners off keeps the entries loaded with `unavailable` entities instead of dropping them, and they recover on their own once power returns.

## Note

Capability-gated controls (power-limit / switches / restart) are skipped while the miner is offline at startup (we can't read `supports_*` yet) and appear after the first successful connection + a reload.
