### PR TITLE
feat: options flow with a configurable scan interval

### DIFF
--- a/custom_components/miner/__init__.py
+++ b/custom_components/miner/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN
 from .coordinator import MinerCoordinator
 
 PLATFORMS = [
@@ -25,12 +25,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ip=entry.data[CONF_HOST],
         username=entry.data.get(CONF_USERNAME),
         password=entry.data.get(CONF_PASSWORD),
+        scan_interval=entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
     )
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(_async_reload_entry))
     return True
+
+
+async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the config entry when its options change."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/miner/config_flow.py
+++ b/custom_components/miner/config_flow.py
@@ -8,12 +8,25 @@ import ipaddress
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.network import async_get_adapters
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.selector import (
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+)
 
 from pyasic_rs import MinerFactory
 
-from .const import DOMAIN
+from .const import (
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    MAX_SCAN_INTERVAL,
+    MIN_SCAN_INTERVAL,
+)
 
 CONF_SUBNET = "subnet"
 CONF_SELECTED_MINER = "selected_miner"
@@ -66,6 +79,11 @@ class AsicMinerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for ASIC Miner."""
 
     VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> "AsicMinerOptionsFlow":
+        return AsicMinerOptionsFlow()
 
     def __init__(self) -> None:
         self._subnet: str = ""
@@ -207,4 +225,39 @@ class AsicMinerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=STEP_CREDENTIALS_SCHEMA,
             description_placeholders={"host": self._selected_ip},
             errors=errors,
+        )
+
+
+class AsicMinerOptionsFlow(config_entries.OptionsFlow):
+    """Options flow for ASIC Miner — configurable polling interval."""
+
+    async def async_step_init(self, user_input=None) -> FlowResult:
+        if user_input is not None:
+            return self.async_create_entry(
+                title="",
+                data={**self.config_entry.options, **user_input},
+            )
+
+        scan_interval_select = NumberSelector(
+            NumberSelectorConfig(
+                min=MIN_SCAN_INTERVAL,
+                max=MAX_SCAN_INTERVAL,
+                step=1,
+                unit_of_measurement="s",
+                mode=NumberSelectorMode.BOX,
+            )
+        )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL,
+                        default=self.config_entry.options.get(
+                            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                        ),
+                    ): scan_interval_select,
+                }
+            ),
         )

--- a/custom_components/miner/const.py
+++ b/custom_components/miner/const.py
@@ -2,4 +2,8 @@
 
 DOMAIN = "miner"
 
+CONF_SCAN_INTERVAL = "scan_interval"
+
 DEFAULT_SCAN_INTERVAL = 30  # seconds
+MIN_SCAN_INTERVAL = 10  # seconds
+MAX_SCAN_INTERVAL = 600  # seconds

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -28,6 +28,7 @@ class MinerCoordinator(DataUpdateCoordinator[MinerData]):
         ip: str,
         username: str | None = None,
         password: str | None = None,
+        scan_interval: int | None = None,
     ) -> None:
         self.ip = ip
         self.username = username
@@ -37,7 +38,7 @@ class MinerCoordinator(DataUpdateCoordinator[MinerData]):
             hass,
             _LOGGER,
             name=f"{DOMAIN}_{ip}",
-            update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
+            update_interval=timedelta(seconds=scan_interval or DEFAULT_SCAN_INTERVAL),
         )
 
     async def _async_setup(self) -> None:

--- a/custom_components/miner/strings.json
+++ b/custom_components/miner/strings.json
@@ -51,5 +51,18 @@
     "abort": {
       "already_configured": "This miner is already configured."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Miner Options",
+        "data": {
+          "scan_interval": "Scan interval (seconds)"
+        },
+        "data_description": {
+          "scan_interval": "How often Home Assistant polls the miner for new data."
+        }
+      }
+    }
   }
 }

--- a/custom_components/miner/translations/en.json
+++ b/custom_components/miner/translations/en.json
@@ -51,5 +51,18 @@
     "abort": {
       "already_configured": "This miner is already configured."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Miner Options",
+        "data": {
+          "scan_interval": "Scan interval (seconds)"
+        },
+        "data_description": {
+          "scan_interval": "How often Home Assistant polls the miner for new data."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## What & why

The polling interval is currently fixed at 30s. This adds an Options flow (there isn't one yet) so the scan interval is configurable per miner without re-adding it — handy for faster updates while tuning, or slower polling across a larger fleet.

## How

- The coordinator takes the interval from the entry options, falling back to the existing 30s default.
- The entry reloads on an options change, so a new interval takes effect immediately.
- A `NumberSelector` (10–600s) in the options `init` step.

It also lays the OptionsFlow groundwork for follow-up options — I've got sensor-category toggles and power-aware polling running downstream that I'll send as separate, focused PRs on top of this.

## Validated

Running in production.
