### PR TITLE
Complete asic-rs integration: categories, power-aware polling, VNish controls (BETA), 4-field temps, safety

### DIFF
--- a/custom_components/miner/__init__.py
+++ b/custom_components/miner/__init__.py
@@ -5,8 +5,16 @@ from __future__ import annotations
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN
+from .const import (
+    CONF_BOOT_TIMEOUT,
+    CONF_POWER_ENTITY,
+    CONF_SCAN_INTERVAL,
+    DEFAULT_BOOT_TIMEOUT,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
 from .coordinator import MinerCoordinator
 
 PLATFORMS = [
@@ -15,22 +23,55 @@ PLATFORMS = [
     Platform.SWITCH,
     Platform.BUTTON,
     Platform.NUMBER,
+    Platform.SELECT,
 ]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up ASIC Miner from a config entry."""
+    # Options override entry data (e.g. a VNish web password added after setup).
+    password = entry.options.get(CONF_PASSWORD) or entry.data.get(CONF_PASSWORD)
     coordinator = MinerCoordinator(
         hass,
         ip=entry.data[CONF_HOST],
+        entry_id=entry.entry_id,
         username=entry.data.get(CONF_USERNAME),
-        password=entry.data.get(CONF_PASSWORD),
+        password=password,
+        scan_interval=entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+        power_entity=entry.options.get(CONF_POWER_ENTITY) or None,
+        boot_timeout=entry.options.get(CONF_BOOT_TIMEOUT, DEFAULT_BOOT_TIMEOUT),
     )
-    await coordinator.async_config_entry_first_refresh()
+    await coordinator.async_setup_power_tracking()
+    entry.async_on_unload(coordinator._stop_power_tracking)
+
+    # Offline resilience: load the cached device profile, then do a NON-raising
+    # refresh. If the miner is reachable we get live data; if not, we may still
+    # have a cached profile and can load entities (showing unavailable).
+    await coordinator.async_load_profile()
+    await coordinator.async_refresh()
+
+    # Only bail (and let HA retry) when we truly know nothing about the miner:
+    # the refresh failed AND we have no cached profile AND no data. A never-seen
+    # miner that is offline at first setup still behaves as before.
+    if (
+        not coordinator.last_update_success
+        and coordinator.profile is None
+        and coordinator.data is None
+    ):
+        raise ConfigEntryNotReady(
+            f"Miner at {entry.data[CONF_HOST]} is unreachable and no cached "
+            "profile exists yet"
+        )
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(_async_reload_entry))
     return True
+
+
+async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload when options change (e.g. category toggles, scan interval, password)."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/miner/binary_sensor.py
+++ b/custom_components/miner/binary_sensor.py
@@ -16,9 +16,16 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from pyasic_rs.data import MinerData
 
-from .const import DOMAIN
+from .const import (
+    CAT_MINER_SUMMARY,
+    CAT_SAFETY,
+    CONF_SENSOR_CATEGORIES,
+    DEFAULT_SENSOR_CATEGORIES,
+    DOMAIN,
+)
 from .coordinator import MinerCoordinator
-from .entity import MinerEntity
+from .entity import MinerEntity, async_remove_stale_entities
+from .sensor import _has_problem
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -27,6 +34,7 @@ class MinerBinarySensorDescription(BinarySensorEntityDescription):
     available_fn: Callable[[MinerData], bool] = lambda _: True
 
 
+# Miner-wide status flags (CAT_MINER_SUMMARY).
 BINARY_SENSORS: tuple[MinerBinarySensorDescription, ...] = (
     MinerBinarySensorDescription(
         key="is_mining",
@@ -41,6 +49,43 @@ BINARY_SENSORS: tuple[MinerBinarySensorDescription, ...] = (
         available_fn=lambda d: d.light_flashing is not None,
     ),
 )
+
+# Safety (CAT_SAFETY): on when the miner reports its own Error/Warning state.
+# Defensive (B2): with no messages on stock 0.6.2, _has_problem -> False.
+SAFETY_BINARY_SENSORS: tuple[MinerBinarySensorDescription, ...] = (
+    MinerBinarySensorDescription(
+        key="safety_problem",
+        name="Safety Problem",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        value_fn=_has_problem,
+    ),
+)
+
+
+class MinerBootTimeoutBinarySensor(MinerEntity, BinarySensorEntity):
+    """Coordinator-backed boot-timeout alarm (not MinerData-backed).
+
+    Only created when a power_entity is configured AND CAT_SAFETY is enabled.
+    Latches ON when the miner fails to come up within boot_timeout after a
+    power-on transition.
+    """
+
+    _attr_name = "Boot Timeout"
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_icon = "mdi:timer-alert"
+
+    def __init__(self, coordinator: MinerCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self._device_unique_id}_boot_timeout"
+
+    @property
+    def is_on(self) -> bool:
+        return self.coordinator.boot_failed
+
+    @property
+    def available(self) -> bool:
+        # The alarm itself is always meaningful while the entity exists.
+        return True
 
 
 class MinerBinarySensorEntity(MinerEntity, BinarySensorEntity):
@@ -74,6 +119,32 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: MinerCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities(
-        MinerBinarySensorEntity(coordinator, desc) for desc in BINARY_SENSORS
+
+    categories = set(
+        entry.options.get(CONF_SENSOR_CATEGORIES, DEFAULT_SENSOR_CATEGORIES)
     )
+
+    descriptions: list[MinerBinarySensorDescription] = []
+    if CAT_MINER_SUMMARY in categories:
+        descriptions.extend(BINARY_SENSORS)
+    if CAT_SAFETY in categories:
+        descriptions.extend(SAFETY_BINARY_SENSORS)
+
+    # Boot-timeout alarm: coordinator-backed, only when power-aware polling is
+    # configured and the safety category is enabled.
+    add_boot_timeout = CAT_SAFETY in categories and coordinator.power_entity
+
+    mac = coordinator.device_mac
+    device_uid = mac.replace(":", "").lower() if mac else coordinator.ip
+    keep = {f"{device_uid}_{d.key}" for d in descriptions}
+    if add_boot_timeout:
+        keep.add(f"{device_uid}_boot_timeout")
+    async_remove_stale_entities(hass, entry, "binary_sensor", keep)
+
+    entities: list[BinarySensorEntity] = [
+        MinerBinarySensorEntity(coordinator, desc) for desc in descriptions
+    ]
+    if add_boot_timeout:
+        entities.append(MinerBootTimeoutBinarySensor(coordinator))
+
+    async_add_entities(entities)

--- a/custom_components/miner/button.py
+++ b/custom_components/miner/button.py
@@ -35,7 +35,10 @@ async def async_setup_entry(
 
     entities: list[MinerEntity] = []
 
-    if coordinator.miner.supports_restart:
+    # Gated on a miner capability flag. When the miner is None (offline at
+    # startup) we cannot know it, so we skip the native entity; it appears after
+    # the first successful connection + a reload.
+    if coordinator.miner is not None and coordinator.miner.supports_restart:
         entities.append(RestartButton(coordinator))
 
     async_add_entities(entities)

--- a/custom_components/miner/config_flow.py
+++ b/custom_components/miner/config_flow.py
@@ -8,12 +8,42 @@ import ipaddress
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.network import async_get_adapters
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.selector import (
+    BooleanSelector,
+    EntitySelector,
+    EntitySelectorConfig,
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
 from pyasic_rs import MinerFactory
 
-from .const import DOMAIN
+from .const import (
+    CONF_BOOT_TIMEOUT,
+    CONF_ONLY_AVAILABLE,
+    CONF_POWER_ENTITY,
+    CONF_SCAN_INTERVAL,
+    CONF_SENSOR_CATEGORIES,
+    DEFAULT_BOOT_TIMEOUT,
+    DEFAULT_ONLY_AVAILABLE,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_SENSOR_CATEGORIES,
+    DOMAIN,
+    MAX_BOOT_TIMEOUT,
+    MAX_SCAN_INTERVAL,
+    MIN_BOOT_TIMEOUT,
+    MIN_SCAN_INTERVAL,
+    SENSOR_CATEGORIES,
+)
 
 CONF_SUBNET = "subnet"
 CONF_SELECTED_MINER = "selected_miner"
@@ -66,6 +96,11 @@ class AsicMinerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for ASIC Miner."""
 
     VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> AsicMinerOptionsFlow:
+        return AsicMinerOptionsFlow()
 
     def __init__(self) -> None:
         self._subnet: str = ""
@@ -207,4 +242,108 @@ class AsicMinerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=STEP_CREDENTIALS_SCHEMA,
             description_placeholders={"host": self._selected_ip},
             errors=errors,
+        )
+
+
+class AsicMinerOptionsFlow(config_entries.OptionsFlow):
+    """Options flow — sensor categories, only-available, poll interval, web password.
+
+    * **Sensor categories**: tick the groups of sensors to create. Unticking a
+      category removes its entities on reload (deterministic / boot-safe).
+    * **Only type-relevant sensors**: hide values that don't apply to this miner
+      (e.g. fluid/water temps on air-cooled, chip temp where unreported).
+    * **Scan interval**: how often the miner is polled.
+    * **Firmware web password** (BETA): lets the VNish preset/throttle controls
+      obtain an unlock token without re-adding the miner.
+
+    Note: HA provides ``self.config_entry`` automatically; do not assign it
+    (it is a read-only property in current HA).
+    """
+
+    async def async_step_init(self, user_input=None) -> FlowResult:
+        if user_input is not None:
+            # Merge over existing options so unrelated keys are preserved.
+            data = {**self.config_entry.options, **user_input}
+            # An empty/unselected power entity must DISABLE power-aware polling,
+            # not silently keep a previously-set value (the merge would otherwise
+            # preserve it). Treat empty/absent as "cleared".
+            if not user_input.get(CONF_POWER_ENTITY):
+                data.pop(CONF_POWER_ENTITY, None)
+            return self.async_create_entry(title="", data=data)
+
+        options = self.config_entry.options
+        current_password = options.get(
+            CONF_PASSWORD, self.config_entry.data.get(CONF_PASSWORD, "")
+        )
+        current_categories = options.get(
+            CONF_SENSOR_CATEGORIES, DEFAULT_SENSOR_CATEGORIES
+        )
+        current_only_available = options.get(
+            CONF_ONLY_AVAILABLE, DEFAULT_ONLY_AVAILABLE
+        )
+        current_scan_interval = options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        current_power_entity = options.get(CONF_POWER_ENTITY, "")
+        current_boot_timeout = options.get(CONF_BOOT_TIMEOUT, DEFAULT_BOOT_TIMEOUT)
+
+        categories_select = SelectSelector(
+            SelectSelectorConfig(
+                options=[
+                    SelectOptionDict(value=cat, label=cat)
+                    for cat in SENSOR_CATEGORIES
+                ],
+                translation_key=CONF_SENSOR_CATEGORIES,
+                multiple=True,
+                mode=SelectSelectorMode.LIST,
+            )
+        )
+        scan_interval_select = NumberSelector(
+            NumberSelectorConfig(
+                min=MIN_SCAN_INTERVAL,
+                max=MAX_SCAN_INTERVAL,
+                step=1,
+                unit_of_measurement="s",
+                mode=NumberSelectorMode.BOX,
+            )
+        )
+        power_entity_select = EntitySelector(
+            EntitySelectorConfig(
+                domain=["switch", "binary_sensor", "input_boolean"]
+            )
+        )
+        boot_timeout_select = NumberSelector(
+            NumberSelectorConfig(
+                min=MIN_BOOT_TIMEOUT,
+                max=MAX_BOOT_TIMEOUT,
+                step=5,
+                unit_of_measurement="s",
+                mode=NumberSelectorMode.BOX,
+            )
+        )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_SENSOR_CATEGORIES, default=current_categories
+                    ): categories_select,
+                    vol.Optional(
+                        CONF_ONLY_AVAILABLE, default=current_only_available
+                    ): BooleanSelector(),
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL, default=current_scan_interval
+                    ): scan_interval_select,
+                    # EntitySelector: no hard default — pass the current value via
+                    # suggested_value so submitting without a selection simply
+                    # omits the key (key absent ⇒ power-aware polling disabled).
+                    vol.Optional(
+                        CONF_POWER_ENTITY,
+                        description={"suggested_value": current_power_entity or None},
+                    ): power_entity_select,
+                    vol.Optional(
+                        CONF_BOOT_TIMEOUT, default=current_boot_timeout
+                    ): boot_timeout_select,
+                    vol.Optional(CONF_PASSWORD, default=current_password): str,
+                }
+            ),
         )

--- a/custom_components/miner/const.py
+++ b/custom_components/miner/const.py
@@ -2,4 +2,49 @@
 
 DOMAIN = "miner"
 
+# ── Options: polling ────────────────────────────────────────────────────────
+CONF_SCAN_INTERVAL = "scan_interval"
 DEFAULT_SCAN_INTERVAL = 30  # seconds
+MIN_SCAN_INTERVAL = 10
+MAX_SCAN_INTERVAL = 600
+
+# ── Options: power-aware polling (optional) ─────────────────────────────────
+# When a power switch/sensor entity is configured, the coordinator pauses
+# network polling while the miner is powered off, runs a fast "boot loop" right
+# after power-on until the miner answers, and latches a boot-timeout alarm if it
+# never comes up in time. Default unset ⇒ exact current behavior (always-on).
+CONF_POWER_ENTITY = "power_entity"
+CONF_BOOT_TIMEOUT = "boot_timeout"
+DEFAULT_BOOT_TIMEOUT = 120  # seconds to wait for the miner after power-on
+MIN_BOOT_TIMEOUT = 30
+MAX_BOOT_TIMEOUT = 600
+BOOT_POLL_INTERVAL = 10  # seconds, the fast loop during boot
+
+# ── Options: which sensors to create ────────────────────────────────────────
+# The asic-rs entity model emits a large number of per-board sensors plus a few
+# type-specific values. The user ticks the categories they want; gating happens
+# at entity-setup time (sensor.py / binary_sensor.py), driven entirely by
+# ``config_entry.options``. Unticking a category removes its entities on reload
+# (deterministic / boot-safe — never based on a transient missing value).
+
+CONF_SENSOR_CATEGORIES = "sensor_categories"
+CONF_ONLY_AVAILABLE = "only_available"
+
+# Category keys.
+CAT_MINER_SUMMARY = "miner_summary"  # miner-wide aggregates/statistics
+CAT_SAFETY = "safety"  # safety alarm: problem flag + reason text
+CAT_BOARD_TEMPS = "board_temps"  # per-board board/chip/intake/outlet temperatures
+CAT_BOARD_PERF = "board_perf"  # per-board hashrate/voltage/frequency/working-chips
+CAT_FANS = "fans"  # fan RPM
+
+SENSOR_CATEGORIES = [
+    CAT_MINER_SUMMARY,
+    CAT_SAFETY,
+    CAT_BOARD_TEMPS,
+    CAT_BOARD_PERF,
+    CAT_FANS,
+]
+
+# Sensible defaults: the everyday summary plus the safety alarm.
+DEFAULT_SENSOR_CATEGORIES = [CAT_MINER_SUMMARY, CAT_SAFETY]
+DEFAULT_ONLY_AVAILABLE = True

--- a/custom_components/miner/coordinator.py
+++ b/custom_components/miner/coordinator.py
@@ -5,14 +5,19 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from pyasic_rs import MinerFactory
 from pyasic_rs.data import MinerData
 from pyasic_rs.miner import Miner
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
+from . import vnish
+from .const import BOOT_POLL_INTERVAL, DEFAULT_BOOT_TIMEOUT, DEFAULT_SCAN_INTERVAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,21 +31,216 @@ class MinerCoordinator(DataUpdateCoordinator[MinerData]):
         self,
         hass: HomeAssistant,
         ip: str,
+        entry_id: str,
         username: str | None = None,
         password: str | None = None,
+        scan_interval: int | None = None,
+        power_entity: str | None = None,
+        boot_timeout: int = DEFAULT_BOOT_TIMEOUT,
     ) -> None:
         self.ip = ip
         self.username = username
         self.password = password
 
+        # ── Offline resilience: cached device profile ──────────────────────
+        # Persisted via Store (NOT entry.data — writing entry.data would trigger
+        # the options update listener and reload-loop). Lets the entry LOAD with
+        # entities (showing unavailable) even when the miner is unreachable at
+        # HA startup. Populated from a successful poll; read as a fallback when
+        # live ``data`` is None.
+        self._store: Store = Store(hass, 1, f"{DOMAIN}_profile_{entry_id}")
+        self.profile: dict | None = None
+
+        # Configured (normal) scan interval — kept so we can restore it after a
+        # boot fast-loop or after power returns.
+        self._scan_interval = scan_interval or DEFAULT_SCAN_INTERVAL
+
+        # BETA VNish control state (populated only for VNish miners).
+        self.is_vnish: bool = False
+        self.vnish_presets: list[str] = []
+        # name -> human Select label (tuned hashrate / "(untuned)" marker).
+        self.vnish_preset_labels: dict[str, str] = {}
+        self.vnish_preset: str | None = None
+        self.vnish_throttle: int | None = None
+        # VNish's own state verdict (mining / tuning / initializing / stopped …),
+        # polled from /summary alongside the throttle. Lets the safety-reason
+        # sensor say "tuning in progress" instead of a bare "OK".
+        self.vnish_state: str | None = None
+
+        # ── Power-aware polling state ──────────────────────────────────────
+        # When no power_entity is configured, power_on stays True forever and
+        # none of the power logic ever fires ⇒ exact legacy behavior.
+        self.power_entity = power_entity or None
+        self.boot_timeout = boot_timeout
+        self.power_on: bool = True
+        self.booting: bool = False
+        self.boot_failed: bool = False
+        self._power_on_since = None
+        self._power_unsub = None
+
         super().__init__(
             hass,
             _LOGGER,
             name=f"{DOMAIN}_{ip}",
-            update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
+            update_interval=timedelta(seconds=self._scan_interval),
         )
 
+    # ── Power tracking ─────────────────────────────────────────────────────
+
+    async def async_setup_power_tracking(self) -> None:
+        """Read the power entity's current state and subscribe to changes.
+
+        Called from __init__.py after the coordinator is created but before the
+        first refresh. No-op when no power_entity is configured.
+        """
+        if not self.power_entity:
+            return
+        state = self.hass.states.get(self.power_entity)
+        # Only an explicit "off" suppresses polling. At HA startup the power
+        # entity's integration may not have loaded yet (state None / "unknown" /
+        # "unavailable"); treating that as off would wrongly suppress a running
+        # miner for the whole session. Default to powered-on in the ambiguous
+        # case — it self-corrects on the next state change.
+        self.power_on = state is None or state.state != "off"
+        self._power_unsub = async_track_state_change_event(
+            self.hass, [self.power_entity], self._handle_power_event
+        )
+
+    @callback
+    def _stop_power_tracking(self) -> None:
+        """Unsubscribe from the power entity (registered on entry unload)."""
+        if self._power_unsub is not None:
+            self._power_unsub()
+            self._power_unsub = None
+
+    @callback
+    def _handle_power_event(self, event) -> None:
+        new = event.data.get("new_state")
+        # Ignore transient/unknown states: only explicit on/off flips the power
+        # state. A power entity briefly going "unavailable" (its integration
+        # reloading) must not be read as powered-off and stop a running miner.
+        if new is None or new.state in ("unavailable", "unknown"):
+            return
+        on = new.state == "on"
+
+        if on and not self.power_on:
+            # OFF → ON: begin the fast boot loop and poll immediately.
+            self.power_on = True
+            self.booting = True
+            self.boot_failed = False
+            self._power_on_since = dt_util.utcnow()
+            self.update_interval = timedelta(seconds=BOOT_POLL_INTERVAL)
+            self.hass.async_create_task(self.async_request_refresh())
+        elif not on and self.power_on:
+            # ON → OFF: stop polling the network, restore normal cadence.
+            self.power_on = False
+            self.booting = False
+            self.boot_failed = False
+            self._power_on_since = None
+            self.update_interval = timedelta(seconds=self._scan_interval)
+            # Push state so entities re-evaluate availability. _async_update_data
+            # will now short-circuit (powered off), so entities go unavailable.
+            self.async_update_listeners()
+
+    # ── Cached device profile (offline resilience) ─────────────────────────
+
+    async def async_load_profile(self) -> None:
+        """Load the persisted device profile (None if no file exists yet).
+
+        Called from __init__.py before the first refresh so that platforms can
+        enumerate per-board / per-fan entities from cache when the miner is
+        offline at startup.
+        """
+        self.profile = await self._store.async_load()
+
+    async def _async_store_profile(self, data: MinerData) -> None:
+        """Persist a fresh profile derived from a successful poll, if changed."""
+        profile = {
+            "mac": data.mac,
+            "make": data.device_info.make,
+            "model": data.device_info.model,
+            "fw": data.firmware_version,
+            "board_positions": [b.position for b in data.hashboards],
+            "fan_positions": [f.position for f in data.fans],
+            "psu_fan_positions": [f.position for f in data.psu_fans],
+            "is_vnish": self.is_vnish,
+        }
+        if profile != self.profile:
+            self.profile = profile
+            await self._store.async_save(profile)
+
+    # Helper properties: prefer live ``data``, fall back to the cached profile,
+    # finally a safe default. Used by entity.py and the platform setups so they
+    # work identically online and offline-with-cache.
+
+    @property
+    def device_mac(self) -> str | None:
+        data = self.data
+        if data is not None and data.mac:
+            return data.mac
+        if self.profile:
+            return self.profile.get("mac")
+        return None
+
+    @property
+    def device_make(self) -> str | None:
+        data = self.data
+        if data is not None and data.device_info.make:
+            return data.device_info.make
+        if self.profile:
+            return self.profile.get("make")
+        return None
+
+    @property
+    def device_model(self) -> str | None:
+        data = self.data
+        if data is not None and data.device_info.model:
+            return data.device_info.model
+        if self.profile:
+            return self.profile.get("model")
+        return None
+
+    @property
+    def fw_version(self) -> str | None:
+        data = self.data
+        if data is not None and data.firmware_version:
+            return data.firmware_version
+        if self.profile:
+            return self.profile.get("fw")
+        return None
+
+    @property
+    def board_positions(self) -> list[int]:
+        data = self.data
+        if data is not None:
+            return [b.position for b in data.hashboards]
+        if self.profile:
+            return list(self.profile.get("board_positions") or [])
+        return []
+
+    @property
+    def fan_positions(self) -> list[int]:
+        data = self.data
+        if data is not None:
+            return [f.position for f in data.fans]
+        if self.profile:
+            return list(self.profile.get("fan_positions") or [])
+        return []
+
+    @property
+    def psu_fan_positions(self) -> list[int]:
+        data = self.data
+        if data is not None:
+            return [f.position for f in data.psu_fans]
+        if self.profile:
+            return list(self.profile.get("psu_fan_positions") or [])
+        return []
+
+    # ── Setup / update ─────────────────────────────────────────────────────
+
     async def _async_setup(self) -> None:
+        if self.power_entity and not self.power_on:
+            raise UpdateFailed("miner powered off")
         factory = MinerFactory()
         miner = await factory.get_miner(self.ip)
         if miner is None:
@@ -49,12 +249,75 @@ class MinerCoordinator(DataUpdateCoordinator[MinerData]):
             miner.set_auth(self.username, self.password)
         self.miner = miner
 
+        # BETA: detect VNish firmware so the preset/throttle entities get added.
+        session = async_get_clientsession(self.hass)
+        self.is_vnish = await vnish.detect_vnish(session, self.ip)
+        detailed: list[dict] = []
+        if self.is_vnish and self.password:
+            detailed = await vnish.fetch_presets(session, self.ip, self.password)
+        if self.is_vnish and not detailed:
+            # No live list (no password / fetch failed): fall back to bare names,
+            # no tuned/un-tuned label info available offline.
+            detailed = [{"name": n} for n in vnish.FALLBACK_PRESETS]
+        if self.is_vnish:
+            self.vnish_presets = [p["name"] for p in detailed]
+            self.vnish_preset_labels = {
+                p["name"]: vnish.preset_label(
+                    p["name"], p.get("pretty"), p.get("status")
+                )
+                for p in detailed
+            }
+
     async def _async_update_data(self) -> MinerData:
+        if self.power_entity and not self.power_on:
+            # Benign: no network call while powered off. Entities go unavailable.
+            raise UpdateFailed("miner powered off")
         if self.miner is None:
             await self._async_setup()
         try:
-            return await self.miner.get_data()
+            data = await self.miner.get_data()
         except Exception as err:
+            # While booting, latch the alarm once the boot timeout has elapsed.
+            if (
+                self.booting
+                and not self.boot_failed
+                and self._power_on_since is not None
+                and (dt_util.utcnow() - self._power_on_since).total_seconds()
+                > self.boot_timeout
+            ):
+                # Boot timed out: latch the alarm and stop hammering at the fast
+                # cadence — fall back to the normal interval. booting stays True
+                # so a later success still clears the alarm and recovers.
+                self.boot_failed = True
+                self.update_interval = timedelta(seconds=self._scan_interval)
             raise UpdateFailed(
                 f"Error communicating with miner at {self.ip}: {err}"
             ) from err
+
+        # Success: if we were booting, the miner is up — clear boot state and
+        # restore the normal polling cadence.
+        if self.booting:
+            self.booting = False
+            self.boot_failed = False
+            self.update_interval = timedelta(seconds=self._scan_interval)
+
+        if self.is_vnish:
+            await self._async_update_vnish()
+
+        # Persist a fresh device profile so the entry can load offline next time.
+        await self._async_store_profile(data)
+        return data
+
+    async def _async_update_vnish(self) -> None:
+        """BETA: refresh VNish preset/throttle. Never fails the main update."""
+        session = async_get_clientsession(self.hass)
+        try:
+            self.vnish_throttle, self.vnish_state = await vnish.fetch_status(
+                session, self.ip
+            )
+            if self.password:
+                self.vnish_preset = await vnish.fetch_current_preset(
+                    session, self.ip, self.password
+                )
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("VNish extra-poll failed for %s: %s", self.ip, err)

--- a/custom_components/miner/entity.py
+++ b/custom_components/miner/entity.py
@@ -2,12 +2,43 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import MinerCoordinator
+
+
+@callback
+def async_remove_stale_entities(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    platform_domain: str,
+    keep_unique_ids: Iterable[str],
+) -> None:
+    """Remove this entry's entities (of one platform) that are no longer produced.
+
+    This is the "cleanup" behind the sensor-category toggles: it is driven purely
+    by the (deterministic) options, so unticking a category removes exactly its
+    entities on the next reload. It is never keyed on a transient/missing value,
+    so it cannot delete an entity just because a miner is briefly unreachable.
+    """
+    keep = set(keep_unique_ids)
+    registry = er.async_get(hass)
+    for ent in list(registry.entities.values()):
+        if (
+            ent.config_entry_id == entry.entry_id
+            and ent.platform == DOMAIN
+            and ent.domain == platform_domain
+            and ent.unique_id not in keep
+        ):
+            registry.async_remove(ent.entity_id)
 
 
 class MinerEntity(CoordinatorEntity[MinerCoordinator]):
@@ -17,21 +48,31 @@ class MinerEntity(CoordinatorEntity[MinerCoordinator]):
 
     def __init__(self, coordinator: MinerCoordinator) -> None:
         super().__init__(coordinator)
-        data = coordinator.data
+        # Build device_info from the coordinator helpers, which prefer live data
+        # and fall back to the cached profile. They tolerate the fully-offline,
+        # never-seen case (everything None) — we then use the IP-based identifier
+        # and a generic name. Never raise on None.
+        mac = coordinator.device_mac
+        make = coordinator.device_make
+        model = coordinator.device_model
+        if make or model:
+            name = " ".join(p for p in (make, model) if p)
+        else:
+            name = f"ASIC Miner ({coordinator.ip})"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._device_unique_id)},
-            connections={(dr.CONNECTION_NETWORK_MAC, data.mac)} if data.mac else set(),
-            name=f"{data.device_info.make} {data.device_info.model}",
-            manufacturer=data.device_info.make,
-            model=data.device_info.model,
-            sw_version=data.firmware_version,
+            connections={(dr.CONNECTION_NETWORK_MAC, mac)} if mac else set(),
+            name=name,
+            manufacturer=make,
+            model=model,
+            sw_version=coordinator.fw_version,
             configuration_url=f"http://{coordinator.ip}",
         )
 
     @property
     def _device_unique_id(self) -> str:
-        """Stable device identifier: prefer MAC over IP."""
-        data = self.coordinator.data
-        if data and data.mac:
-            return data.mac.replace(":", "").lower()
+        """Stable device identifier: prefer MAC (live or cached) over IP."""
+        mac = self.coordinator.device_mac
+        if mac:
+            return mac.replace(":", "").lower()
         return self.coordinator.ip

--- a/custom_components/miner/number.py
+++ b/custom_components/miner/number.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfPower
+from homeassistant.const import PERCENTAGE, UnitOfPower
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import vnish
 from .const import DOMAIN
 from .coordinator import MinerCoordinator
 from .entity import MinerEntity
@@ -44,6 +46,42 @@ class PowerLimitNumber(MinerEntity, NumberEntity):
         await self.coordinator.async_request_refresh()
 
 
+class VnishThrottleNumber(MinerEntity, NumberEntity):
+    """[BETA] Set the VNish throttle (percent of full power).
+
+    asic-rs is read-only for VNish power, so this drives the VNish REST API
+    directly (see vnish.py). Replace once asic-rs supports VNish writes.
+    """
+
+    _attr_name = "VNish Throttle"
+    _attr_icon = "mdi:speedometer-slow"
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_native_min_value = float(vnish.THROTTLE_MIN)
+    _attr_native_max_value = float(vnish.THROTTLE_MAX)
+    _attr_native_step = 1.0
+    _attr_mode = NumberMode.SLIDER
+
+    def __init__(self, coordinator: MinerCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self._device_unique_id}_vnish_throttle"
+
+    @property
+    def native_value(self) -> float | None:
+        return self.coordinator.vnish_throttle
+
+    async def async_set_native_value(self, value: float) -> None:
+        session = async_get_clientsession(self.hass)
+        ok, msg = await vnish.set_throttle(
+            session, self.coordinator.ip, self.coordinator.password, int(value)
+        )
+        if ok:
+            self.coordinator.vnish_throttle = int(value)
+            self.async_write_ha_state()
+        else:
+            raise RuntimeError(f"VNish throttle {int(value)}% failed: {msg}")
+        await self.coordinator.async_request_refresh()
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -53,7 +91,21 @@ async def async_setup_entry(
 
     entities: list[MinerEntity] = []
 
-    if coordinator.miner.supports_set_power_limit:
+    # Native PowerLimit is gated on a miner capability flag. When the miner is
+    # None (offline at startup) we cannot know it, so we skip the native entity;
+    # it appears after the first successful connection + a reload.
+    if (
+        coordinator.miner is not None
+        and coordinator.miner.supports_set_power_limit
+    ):
         entities.append(PowerLimitNumber(coordinator))
+
+    # BETA: VNish throttle for VNish-firmware miners (asic-rs read-only here).
+    # VNish detection falls back to the cached profile when offline at startup.
+    is_vnish = coordinator.is_vnish or bool(
+        coordinator.profile and coordinator.profile.get("is_vnish")
+    )
+    if is_vnish:
+        entities.append(VnishThrottleNumber(coordinator))
 
     async_add_entities(entities)

--- a/custom_components/miner/select.py
+++ b/custom_components/miner/select.py
@@ -1,0 +1,98 @@
+"""Select platform for ASIC Miner integration.
+
+BETA SOLUTION: VNish autotune-preset control. asic-rs is read-only for VNish
+presets, so this entity drives the VNish REST API directly (see vnish.py).
+Replace with the native miner method once asic-rs supports VNish writes.
+"""
+
+from __future__ import annotations
+
+import re
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import vnish
+from .const import DOMAIN
+from .coordinator import MinerCoordinator
+from .entity import MinerEntity
+
+
+class VnishPresetSelect(MinerEntity, SelectEntity):
+    """[BETA] Select a VNish autotune preset by name."""
+
+    _attr_name = "VNish Preset"
+    _attr_icon = "mdi:speedometer"
+
+    def __init__(self, coordinator: MinerCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self._device_unique_id}_vnish_preset"
+
+    def _label_for(self, name: str | None) -> str | None:
+        if name is None:
+            return None
+        return self.coordinator.vnish_preset_labels.get(name, name)
+
+    def _name_for(self, label: str) -> str:
+        """Map a displayed label back to the canonical preset name VNish expects.
+
+        Prefer the exact label→name map; fall back to pulling the leading watt
+        number straight out of the label (VNish preset names are the bare number,
+        e.g. ``3495 W ~ 132 TH`` → ``3495``) so selection still resolves even if
+        the label map is stale or empty (e.g. offline). A label with no number
+        (``Disabled``) is returned lowercased to match the ``disabled`` preset.
+        """
+        for name, lbl in self.coordinator.vnish_preset_labels.items():
+            if lbl == label:
+                return name
+        m = re.match(r"\s*(\d+)", label)
+        if m:
+            return m.group(1)
+        return label.strip().lower()
+
+    @property
+    def options(self) -> list[str]:
+        names = self.coordinator.vnish_presets or list(vnish.FALLBACK_PRESETS)
+        return [self._label_for(n) for n in names]
+
+    @property
+    def current_option(self) -> str | None:
+        return self._label_for(self.coordinator.vnish_preset)
+
+    async def async_select_option(self, option: str) -> None:
+        # ``option`` is the display label (e.g. "3495 W ~ 132 TH"); the VNish API
+        # needs the bare preset name ("3495").
+        name = self._name_for(option)
+        session = async_get_clientsession(self.hass)
+        ok, msg = await vnish.apply_preset(
+            session, self.coordinator.ip, self.coordinator.password, name
+        )
+        if ok:
+            self.coordinator.vnish_preset = name
+            self.async_write_ha_state()
+        else:
+            raise RuntimeError(f"VNish preset '{name}' failed: {msg}")
+        await self.coordinator.async_request_refresh()
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator: MinerCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    entities: list[MinerEntity] = []
+
+    # VNish detection comes from the live connection; when offline-at-startup we
+    # fall back to the cached profile so the shim entities still appear.
+    is_vnish = coordinator.is_vnish or bool(
+        coordinator.profile and coordinator.profile.get("is_vnish")
+    )
+    if is_vnish:
+        entities.append(VnishPresetSelect(coordinator))
+
+    async_add_entities(entities)

--- a/custom_components/miner/sensor.py
+++ b/custom_components/miner/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    EntityCategory,
     UnitOfElectricPotential,
     UnitOfFrequency,
     UnitOfPower,
@@ -23,15 +24,61 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from pyasic_rs.data import BoardData, MinerData, HashRateUnit
+from pyasic_rs.data import BoardData, HashRateUnit, MinerData
 
-from .const import DOMAIN
+from .const import (
+    CAT_BOARD_PERF,
+    CAT_BOARD_TEMPS,
+    CAT_FANS,
+    CAT_MINER_SUMMARY,
+    CAT_SAFETY,
+    CONF_ONLY_AVAILABLE,
+    CONF_SENSOR_CATEGORIES,
+    DEFAULT_ONLY_AVAILABLE,
+    DEFAULT_SENSOR_CATEGORIES,
+    DOMAIN,
+)
 from .coordinator import MinerCoordinator
-from .entity import MinerEntity
+from .entity import MinerEntity, async_remove_stale_entities
 
 UNIT_TH_S = "TH/s"
 UNIT_J_TH = "J/TH"
 UNIT_RPM = "RPM"
+
+# Severities (lowercased) that count as an active safety alarm.
+_PROBLEM_SEVERITIES = ("error", "warning")
+
+# Icons for sensors that would otherwise fall back to HA's generic icon.
+# device_class sensors (temperature/power/…) keep their nice default icon
+# unless overridden here. Per-board/fan keys are matched by suffix below.
+_ICONS: dict[str, str] = {
+    "hashrate": "mdi:pickaxe",
+    "expected_hashrate": "mdi:pickaxe",
+    "efficiency": "mdi:gauge",
+    "wattage": "mdi:flash",
+    "uptime": "mdi:timer-outline",
+    "total_chips": "mdi:chip",
+    "pool_accepted_shares": "mdi:check",
+    "pool_rejected_shares": "mdi:close",
+    "pool_url": "mdi:swim",
+    "fluid_temperature": "mdi:thermometer-water",
+    "outlet_fluid_temperature": "mdi:thermometer-water",
+    "safety_alarm_reason": "mdi:shield-alert",
+}
+_ICON_SUFFIXES: dict[str, str] = {
+    "_hashrate": "mdi:pickaxe",
+    "_working_chips": "mdi:chip",
+    "_rpm": "mdi:fan",
+}
+
+
+def _icon_for(key: str) -> str | None:
+    if key in _ICONS:
+        return _ICONS[key]
+    for suffix, icon in _ICON_SUFFIXES.items():
+        if key.endswith(suffix):
+            return icon
+    return None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -40,7 +87,162 @@ class MinerSensorEntityDescription(SensorEntityDescription):
     available_fn: Callable[[MinerData], bool] = lambda _: True
 
 
-# ── Top-level miner sensors ────────────────────────────────────────────────
+# ── Defensive capability helpers (Schicht B / B1) ───────────────────────────
+# These read fields that exist only on the fork wheel; on stock pyasic-rs==0.6.2
+# they are absent and return None so the only_available None-gate (A4) decides.
+
+
+def _cooling_is_hydro(data: MinerData) -> bool | None:
+    """True/False if the lib reports a cooling type, else None (unknown)."""
+    cooling = getattr(getattr(data, "device_info", None), "cooling", None)
+    if cooling is None:
+        return None  # unknown on this lib version -> let only_available decide
+    return str(cooling).lower() in ("hydro", "water", "liquid")
+
+
+def _reports_chip_temp(data: MinerData) -> bool | None:
+    """Lib's reports_chip_temperature flag, or None if absent on this lib."""
+    return getattr(getattr(data, "device_info", None), "reports_chip_temperature", None)
+
+
+# ── shared data helpers ─────────────────────────────────────────────────────
+
+
+def _primary_pool(data: MinerData):
+    """Return the first active pool across all pool groups, or the very first pool."""
+    for group in data.pools:
+        for pool in group.pools:
+            if pool.active:
+                return pool
+    for group in data.pools:
+        if group.pools:
+            return group.pools[0]
+    return None
+
+
+def _primary_pool_accepted(data: MinerData) -> int | None:
+    pool = _primary_pool(data)
+    return pool.accepted_shares if pool else None
+
+
+def _primary_pool_rejected(data: MinerData) -> int | None:
+    pool = _primary_pool(data)
+    return pool.rejected_shares if pool else None
+
+
+def _primary_pool_url(data: MinerData) -> str | None:
+    pool = _primary_pool(data)
+    return pool.url if pool else None
+
+
+def _board_value(
+    data: MinerData, position: int, getter: Callable[[BoardData], Any]
+) -> Any:
+    for board in data.hashboards:
+        if board.position == position:
+            return getter(board)
+    return None
+
+
+def _fan_rpm(data: MinerData, position: int, psu: bool) -> float | None:
+    fans = data.psu_fans if psu else data.fans
+    for fan in fans:
+        if fan.position == position:
+            return fan.rpm
+    return None
+
+
+def _max_temperature(data: MinerData) -> float | None:
+    """Hottest temperature reported across boards plus miner-wide temps.
+
+    Per-board chip temps (``inlet_chip_temperature``/``outlet_chip_temperature``)
+    and the miner-level coolant outlet (``outlet_fluid_temperature``) are read
+    defensively, since not every lib version / miner exposes them.
+    """
+    temps: list[float] = []
+    for board in data.hashboards:
+        for t in (
+            board.board_temperature,
+            getattr(board, "inlet_chip_temperature", None),
+            getattr(board, "outlet_chip_temperature", None),
+        ):
+            if t is not None:
+                temps.append(t)
+    for t in (
+        data.average_temperature,
+        getattr(data, "fluid_temperature", None),
+        getattr(data, "outlet_fluid_temperature", None),
+    ):
+        if t is not None:
+            temps.append(t)
+    return max(temps) if temps else None
+
+
+# ── Safety helpers (Schicht B / B2) ─────────────────────────────────────────
+# All lib-dependent reads are defensive: with no messages and no thermal limits
+# on stock 0.6.2 these reduce to _has_problem -> False and _alarm_reason -> "OK".
+
+
+def _problem_messages(data: MinerData) -> list[str]:
+    """Texts of the miner's own Error/Warning messages (its self-assessment).
+
+    Defensive about both the presence of ``data.messages`` and the message
+    object's shape: severity via ``.severity``, text via ``.message``/``.text``.
+    """
+    out: list[str] = []
+    messages = getattr(data, "messages", None) or []
+    for message in messages:
+        try:
+            severity = str(getattr(message, "severity", "") or "").lower()
+            if severity not in _PROBLEM_SEVERITIES:
+                continue
+            text = getattr(message, "message", None)
+            if text is None:
+                text = getattr(message, "text", None)
+            text = str(text or "").strip()
+            if text and severity:
+                out.append(f"{severity}: {text}")
+            elif text:
+                out.append(text)
+            elif severity:
+                out.append(severity)
+        except Exception:  # noqa: BLE001 - never let a sensor crash setup/update
+            continue
+    return out
+
+
+def _has_problem(data: MinerData) -> bool:
+    return bool(_problem_messages(data))
+
+
+def _alarm_reason(data: MinerData) -> str:
+    """Human-readable alarm reason, aligned to device messages and thermal limits.
+
+    ``OK`` when the miner reports nothing actionable. Device-read limits
+    (``min_startup_temperature`` / ``restart_temperature``) and live temperatures
+    are read defensively, so on stock 0.6.2 (no messages, no limits) this is "OK".
+    """
+    reasons: list[str] = list(_problem_messages(data))
+
+    hot = getattr(data, "restart_temperature", None)
+    cold = getattr(data, "min_startup_temperature", None)
+    maxtemp = _max_temperature(data)
+    inlet = getattr(data, "fluid_temperature", None)
+
+    if hot is not None and maxtemp is not None and maxtemp >= hot:
+        reasons.append(f"too hot ({maxtemp:.0f} °C ≥ {hot:.0f} °C)")
+    if cold is not None and inlet is not None and inlet < cold:
+        reasons.append(
+            f"inlet water too cold (mining won't start) "
+            f"({inlet:.0f} °C < {cold:.0f} °C)"
+        )
+
+    if not reasons:
+        return "OK"
+    return "; ".join(reasons)
+
+
+# ── Miner-Summary: miner-wide aggregates / statistics (CAT_MINER_SUMMARY) ────
 
 MINER_SENSORS: tuple[MinerSensorEntityDescription, ...] = (
     MinerSensorEntityDescription(
@@ -50,9 +252,7 @@ MINER_SENSORS: tuple[MinerSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
         value_fn=lambda d: (
-            round(d.hashrate.into_unit(HashRateUnit.TH).value, 4)
-            if d.hashrate
-            else None
+            round(d.hashrate.into_unit(HashRateUnit.TH).value, 4) if d.hashrate else None
         ),
         available_fn=lambda d: d.hashrate is not None,
     ),
@@ -80,14 +280,39 @@ MINER_SENSORS: tuple[MinerSensorEntityDescription, ...] = (
         available_fn=lambda d: d.average_temperature is not None,
     ),
     MinerSensorEntityDescription(
-        key="fluid_temperature",
-        name="Fluid Temperature",
+        key="max_temperature",
+        name="Max Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
-        value_fn=lambda d: d.fluid_temperature,
-        available_fn=lambda d: d.fluid_temperature is not None,
+        icon="mdi:thermometer-alert",
+        value_fn=_max_temperature,
+        available_fn=lambda d: _max_temperature(d) is not None,
+    ),
+    # Coolant inlet — the miner-level fluid temperature (water inlet on hydro).
+    MinerSensorEntityDescription(
+        key="fluid_temperature",
+        name="Coolant Inlet",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        value_fn=lambda d: getattr(d, "fluid_temperature", None),
+        available_fn=lambda d: getattr(d, "fluid_temperature", None) is not None,
+    ),
+    # Coolant outlet — the miner-level exhaust/return fluid temperature. Only
+    # present on water-cooled miners with the sensor; None (and thus dropped)
+    # otherwise.
+    MinerSensorEntityDescription(
+        key="outlet_fluid_temperature",
+        name="Coolant Outlet",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        value_fn=lambda d: getattr(d, "outlet_fluid_temperature", None),
+        available_fn=lambda d: getattr(d, "outlet_fluid_temperature", None) is not None,
     ),
     MinerSensorEntityDescription(
         key="wattage",
@@ -129,58 +354,122 @@ MINER_SENSORS: tuple[MinerSensorEntityDescription, ...] = (
         key="pool_accepted_shares",
         name="Pool Accepted Shares",
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda d: _primary_pool_accepted(d),
+        value_fn=_primary_pool_accepted,
         available_fn=lambda d: _primary_pool_accepted(d) is not None,
     ),
     MinerSensorEntityDescription(
         key="pool_rejected_shares",
         name="Pool Rejected Shares",
         state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda d: _primary_pool_rejected(d),
+        value_fn=_primary_pool_rejected,
         available_fn=lambda d: _primary_pool_rejected(d) is not None,
     ),
     MinerSensorEntityDescription(
         key="pool_url",
         name="Active Pool",
-        value_fn=lambda d: _primary_pool_url(d),
+        value_fn=_primary_pool_url,
         available_fn=lambda d: _primary_pool_url(d) is not None,
     ),
 )
 
-
-def _primary_pool(data: MinerData):
-    """Return the first active pool across all pool groups, or the very first pool."""
-    for group in data.pools:
-        for pool in group.pools:
-            if pool.active:
-                return pool
-    # Fall back to first pool if none are marked active
-    for group in data.pools:
-        if group.pools:
-            return group.pools[0]
-    return None
+# Members of Miner-Summary that only make sense on liquid-cooled miners. When the
+# lib reports cooling we trust it; otherwise the only_available None-gate decides.
+_SUMMARY_HYDRO_ONLY = ("fluid_temperature", "outlet_fluid_temperature")
 
 
-def _primary_pool_accepted(data: MinerData) -> int | None:
-    pool = _primary_pool(data)
-    return pool.accepted_shares if pool else None
+# ── Safety / Diagnose (CAT_SAFETY) ──────────────────────────────────────────
 
+# The safety alarm reason is now a dedicated coordinator-aware entity
+# (``MinerSafetyReasonSensor``) so it can also surface the boot-timeout latch,
+# rather than a data-only value_fn description.
 
-def _primary_pool_rejected(data: MinerData) -> int | None:
-    pool = _primary_pool(data)
-    return pool.rejected_shares if pool else None
-
-
-def _primary_pool_url(data: MinerData) -> str | None:
-    pool = _primary_pool(data)
-    return pool.url if pool else None
+# The device's OWN configured thermal limits, surfaced as diagnostics so the
+# alarm's comparison values are visible. Schicht B: read defensively, so they
+# only appear when the lib exposes them (dormant on stock 0.6.2).
+SAFETY_LIMIT_SENSORS: tuple[MinerSensorEntityDescription, ...] = (
+    MinerSensorEntityDescription(
+        key="safety_cold_limit",
+        name="Safety Cold Limit",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:thermometer-low",
+        value_fn=lambda d: getattr(d, "min_startup_temperature", None),
+        available_fn=lambda d: getattr(d, "min_startup_temperature", None) is not None,
+    ),
+    MinerSensorEntityDescription(
+        key="safety_hot_limit",
+        name="Safety Hot Limit",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        icon="mdi:thermometer-high",
+        value_fn=lambda d: getattr(d, "restart_temperature", None),
+        available_fn=lambda d: getattr(d, "restart_temperature", None) is not None,
+    ),
+)
 
 
 # ── Per-board sensor factories ──────────────────────────────────────────────
 
 
-def _board_sensors(board: BoardData) -> list[MinerSensorEntityDescription]:
-    n = board.position
+def _board_temp_sensors(n: int) -> list[MinerSensorEntityDescription]:
+    """Per-board temperature sensors (CAT_BOARD_TEMPS).
+
+    ``board_{n}_inlet_chip_temperature`` / ``board_{n}_outlet_chip_temperature``
+    (B3) read the inlet-/outlet-side CHIP temps defensively; where the firmware
+    doesn't report chip temps the value is None and only_available drops them.
+    The PCB ``board_temperature`` sensor is always emitted.
+    """
+    return [
+        MinerSensorEntityDescription(
+            key=f"board_{n}_board_temperature",
+            name=f"Board {n} Temperature",
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            state_class=SensorStateClass.MEASUREMENT,
+            suggested_display_precision=1,
+            value_fn=lambda d, _n=n: _board_value(d, _n, lambda b: b.board_temperature),
+            available_fn=lambda d, _n=n: _board_value(
+                d, _n, lambda b: b.board_temperature
+            )
+            is not None,
+        ),
+        MinerSensorEntityDescription(
+            key=f"board_{n}_inlet_chip_temperature",
+            name=f"Board {n} Chip Temp (inlet)",
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            state_class=SensorStateClass.MEASUREMENT,
+            suggested_display_precision=1,
+            value_fn=lambda d, _n=n: _board_value(
+                d, _n, lambda b: getattr(b, "inlet_chip_temperature", None)
+            ),
+            available_fn=lambda d, _n=n: _board_value(
+                d, _n, lambda b: getattr(b, "inlet_chip_temperature", None)
+            )
+            is not None,
+        ),
+        MinerSensorEntityDescription(
+            key=f"board_{n}_outlet_chip_temperature",
+            name=f"Board {n} Chip Temp (outlet)",
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            state_class=SensorStateClass.MEASUREMENT,
+            suggested_display_precision=1,
+            value_fn=lambda d, _n=n: _board_value(
+                d, _n, lambda b: getattr(b, "outlet_chip_temperature", None)
+            ),
+            available_fn=lambda d, _n=n: _board_value(
+                d, _n, lambda b: getattr(b, "outlet_chip_temperature", None)
+            )
+            is not None,
+        ),
+    ]
+
+
+def _board_perf_sensors(n: int) -> list[MinerSensorEntityDescription]:
+    """Per-board performance sensors (CAT_BOARD_PERF)."""
     return [
         MinerSensorEntityDescription(
             key=f"board_{n}_hashrate",
@@ -197,58 +486,16 @@ def _board_sensors(board: BoardData) -> list[MinerSensorEntityDescription]:
                     else None
                 ),
             ),
-            available_fn=lambda d, _n=n: (
-                _board_value(d, _n, lambda b: b.hashrate) is not None
-            ),
-        ),
-        MinerSensorEntityDescription(
-            key=f"board_{n}_board_temperature",
-            name=f"Board {n} Temperature",
-            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-            device_class=SensorDeviceClass.TEMPERATURE,
-            state_class=SensorStateClass.MEASUREMENT,
-            suggested_display_precision=1,
-            value_fn=lambda d, _n=n: _board_value(d, _n, lambda b: b.board_temperature),
-            available_fn=lambda d, _n=n: (
-                _board_value(d, _n, lambda b: b.board_temperature) is not None
-            ),
-        ),
-        MinerSensorEntityDescription(
-            key=f"board_{n}_intake_temperature",
-            name=f"Board {n} Intake Temperature",
-            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-            device_class=SensorDeviceClass.TEMPERATURE,
-            state_class=SensorStateClass.MEASUREMENT,
-            suggested_display_precision=1,
-            value_fn=lambda d, _n=n: _board_value(
-                d, _n, lambda b: b.intake_temperature
-            ),
-            available_fn=lambda d, _n=n: (
-                _board_value(d, _n, lambda b: b.intake_temperature) is not None
-            ),
-        ),
-        MinerSensorEntityDescription(
-            key=f"board_{n}_outlet_temperature",
-            name=f"Board {n} Outlet Temperature",
-            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-            device_class=SensorDeviceClass.TEMPERATURE,
-            state_class=SensorStateClass.MEASUREMENT,
-            suggested_display_precision=1,
-            value_fn=lambda d, _n=n: _board_value(
-                d, _n, lambda b: b.outlet_temperature
-            ),
-            available_fn=lambda d, _n=n: (
-                _board_value(d, _n, lambda b: b.outlet_temperature) is not None
-            ),
+            available_fn=lambda d, _n=n: _board_value(d, _n, lambda b: b.hashrate)
+            is not None,
         ),
         MinerSensorEntityDescription(
             key=f"board_{n}_working_chips",
             name=f"Board {n} Working Chips",
             state_class=SensorStateClass.MEASUREMENT,
             value_fn=lambda d, _n=n: _board_value(d, _n, lambda b: b.working_chips),
-            available_fn=lambda d, _n=n: (
-                _board_value(d, _n, lambda b: b.working_chips) is not None
-            ),
+            available_fn=lambda d, _n=n: _board_value(d, _n, lambda b: b.working_chips)
+            is not None,
         ),
         MinerSensorEntityDescription(
             key=f"board_{n}_frequency",
@@ -258,9 +505,8 @@ def _board_sensors(board: BoardData) -> list[MinerSensorEntityDescription]:
             state_class=SensorStateClass.MEASUREMENT,
             suggested_display_precision=0,
             value_fn=lambda d, _n=n: _board_value(d, _n, lambda b: b.frequency),
-            available_fn=lambda d, _n=n: (
-                _board_value(d, _n, lambda b: b.frequency) is not None
-            ),
+            available_fn=lambda d, _n=n: _board_value(d, _n, lambda b: b.frequency)
+            is not None,
         ),
         MinerSensorEntityDescription(
             key=f"board_{n}_voltage",
@@ -270,23 +516,10 @@ def _board_sensors(board: BoardData) -> list[MinerSensorEntityDescription]:
             state_class=SensorStateClass.MEASUREMENT,
             suggested_display_precision=2,
             value_fn=lambda d, _n=n: _board_value(d, _n, lambda b: b.voltage),
-            available_fn=lambda d, _n=n: (
-                _board_value(d, _n, lambda b: b.voltage) is not None
-            ),
+            available_fn=lambda d, _n=n: _board_value(d, _n, lambda b: b.voltage)
+            is not None,
         ),
     ]
-
-
-def _board_value(
-    data: MinerData, position: int, getter: Callable[[BoardData], Any]
-) -> Any:
-    for board in data.hashboards:
-        if board.position == position:
-            return getter(board)
-    return None
-
-
-# ── Per-fan sensor factories ────────────────────────────────────────────────
 
 
 def _fan_sensor(position: int, psu: bool = False) -> MinerSensorEntityDescription:
@@ -303,14 +536,6 @@ def _fan_sensor(position: int, psu: bool = False) -> MinerSensorEntityDescriptio
     )
 
 
-def _fan_rpm(data: MinerData, position: int, psu: bool) -> float | None:
-    fans = data.psu_fans if psu else data.fans
-    for fan in fans:
-        if fan.position == position:
-            return fan.rpm
-    return None
-
-
 # ── Entity class ────────────────────────────────────────────────────────────
 
 
@@ -325,6 +550,10 @@ class MinerSensorEntity(MinerEntity, SensorEntity):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{self._device_unique_id}_{description.key}"
+        if description.icon is None:
+            icon = _icon_for(description.key)
+            if icon is not None:
+                self._attr_icon = icon
 
     @property
     def native_value(self) -> Any:
@@ -339,6 +568,58 @@ class MinerSensorEntity(MinerEntity, SensorEntity):
         return self.entity_description.available_fn(self.coordinator.data)
 
 
+class MinerSafetyReasonSensor(MinerEntity, SensorEntity):
+    """Coordinator-aware safety alarm reason.
+
+    Unlike the data-only sensors this also surfaces the coordinator-level
+    boot-timeout latch (which is not part of MinerData), so the reason text can
+    explain a miner that never came up after power-on. Keeps the historic key
+    ``safety_alarm_reason`` so the unique_id is unchanged from earlier alphas.
+    """
+
+    _attr_name = "Safety Alarm Reason"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:shield-alert"
+
+    def __init__(self, coordinator: MinerCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self._device_unique_id}_safety_alarm_reason"
+
+    @property
+    def native_value(self) -> str:
+        coordinator = self.coordinator
+        data = coordinator.data
+        if coordinator.boot_failed:
+            boot_msg = (
+                f"miner did not come online within {coordinator.boot_timeout}s "
+                "after power-on"
+            )
+            if data is not None:
+                reason = _alarm_reason(data)
+                if reason and reason != "OK":
+                    return f"{boot_msg}; {reason}"
+            return boot_msg
+        if data is not None:
+            reason = _alarm_reason(data)
+            # VNish treats tuning as a normal state (no message → reason "OK"),
+            # but surfacing it as info explains why hashrate is ramping/variable.
+            if reason == "OK":
+                state = (coordinator.vnish_state or "").lower()
+                if state in ("tuning", "auto-tuning", "auto_tuning"):
+                    return "tuning in progress"
+            return reason
+        # No data and not a boot failure: distinguish "powered off" from a plain
+        # communication outage so the reason text is meaningful while offline.
+        if coordinator.power_entity and not coordinator.power_on:
+            return "powered off"
+        return "unavailable"
+
+    @property
+    def available(self) -> bool:
+        # Always meaningful while the entity exists (boot/offline reasons too).
+        return True
+
+
 # ── Platform setup ──────────────────────────────────────────────────────────
 
 
@@ -350,18 +631,82 @@ async def async_setup_entry(
     coordinator: MinerCoordinator = hass.data[DOMAIN][entry.entry_id]
     data = coordinator.data
 
-    descriptions: list[MinerSensorEntityDescription] = list(MINER_SENSORS)
+    categories = set(
+        entry.options.get(CONF_SENSOR_CATEGORIES, DEFAULT_SENSOR_CATEGORIES)
+    )
+    only_available = entry.options.get(CONF_ONLY_AVAILABLE, DEFAULT_ONLY_AVAILABLE)
 
-    # Add per-board sensors for each detected hashboard
-    for board in data.hashboards:
-        descriptions.extend(_board_sensors(board))
+    # Capability gates (Schicht B / B1), defensive: True/False when the lib knows,
+    # None on stock 0.6.2 / when offline so the only_available None-gate decides.
+    is_hydro = _cooling_is_hydro(data) if data is not None else None
+    reports_chip = _reports_chip_temp(data) if data is not None else None
 
-    # Add fan sensors
-    for fan in data.fans:
-        descriptions.append(_fan_sensor(fan.position, psu=False))
+    descriptions: list[MinerSensorEntityDescription] = []
+    # The coordinator-backed safety-reason sensor is added separately (it is not
+    # a value_fn description); track it here so stale-cleanup keeps it.
+    extra_keys: set[str] = set()
+    add_safety_reason = False
 
-    # Add PSU fan sensors
-    for fan in data.psu_fans:
-        descriptions.append(_fan_sensor(fan.position, psu=True))
+    # Miner-wide aggregates / statistics.
+    if CAT_MINER_SUMMARY in categories:
+        for d in MINER_SENSORS:
+            # Hydro-only members: drop only when the lib positively says "not hydro".
+            if d.key in _SUMMARY_HYDRO_ONLY and is_hydro is False:
+                continue
+            descriptions.append(d)
 
-    async_add_entities(MinerSensorEntity(coordinator, desc) for desc in descriptions)
+    # Safety / diagnose: the coordinator-aware alarm reason + device thermal limits.
+    if CAT_SAFETY in categories:
+        add_safety_reason = True
+        extra_keys.add("safety_alarm_reason")
+        descriptions.extend(SAFETY_LIMIT_SENSORS)
+
+    # Per-board sensors, enumerated from the coordinator (live data when present,
+    # else the cached profile) so they exist even when the miner is offline.
+    if CAT_BOARD_TEMPS in categories or CAT_BOARD_PERF in categories:
+        for n in coordinator.board_positions:
+            if CAT_BOARD_TEMPS in categories:
+                chip_keys = (
+                    f"board_{n}_inlet_chip_temperature",
+                    f"board_{n}_outlet_chip_temperature",
+                )
+                for d in _board_temp_sensors(n):
+                    # Chip temps: drop only when the lib positively says they
+                    # aren't reported.
+                    if d.key in chip_keys and reports_chip is False:
+                        continue
+                    descriptions.append(d)
+            if CAT_BOARD_PERF in categories:
+                descriptions.extend(_board_perf_sensors(n))
+
+    # Fan RPM sensors, enumerated from the coordinator (live data or cache).
+    if CAT_FANS in categories:
+        for pos in coordinator.fan_positions:
+            descriptions.append(_fan_sensor(pos, psu=False))
+        for pos in coordinator.psu_fan_positions:
+            descriptions.append(_fan_sensor(pos, psu=True))
+
+    # only_available gate (A4): drop descriptions whose value is unavailable now.
+    # When offline (data is None) we cannot evaluate availability — create
+    # everything from the profile; the entities are unavailable anyway until a
+    # poll succeeds, and a later reload re-applies the filter.
+    if only_available and data is not None:
+        descriptions = [d for d in descriptions if d.available_fn(data)]
+
+    # Clean up entities of any category/sensor we are no longer producing
+    # (same unique-id scheme as MinerEntity). device_uid prefers MAC (live or
+    # cached) so we never wipe entities just because the miner is momentarily
+    # offline.
+    mac = coordinator.device_mac
+    device_uid = mac.replace(":", "").lower() if mac else coordinator.ip
+    keep = {f"{device_uid}_{d.key}" for d in descriptions} | {
+        f"{device_uid}_{k}" for k in extra_keys
+    }
+    async_remove_stale_entities(hass, entry, "sensor", keep)
+
+    entities: list[SensorEntity] = [
+        MinerSensorEntity(coordinator, desc) for desc in descriptions
+    ]
+    if add_safety_reason:
+        entities.append(MinerSafetyReasonSensor(coordinator))
+    async_add_entities(entities)

--- a/custom_components/miner/strings.json
+++ b/custom_components/miner/strings.json
@@ -51,5 +51,39 @@
     "abort": {
       "already_configured": "This miner is already configured."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Miner Options",
+        "description": "Tick which sensor categories to create. Unticking a category removes its entities on the next reload. Changing any option reloads the integration.",
+        "data": {
+          "sensor_categories": "Sensor categories",
+          "only_available": "Only create type-relevant sensors",
+          "scan_interval": "Update interval (seconds)",
+          "power_entity": "Power switch entity (optional)",
+          "boot_timeout": "Boot timeout (seconds)",
+          "password": "Firmware web password (BETA, for VNish)"
+        },
+        "data_description": {
+          "sensor_categories": "Tick the groups to create. Unticked groups are removed on reload.",
+          "only_available": "Skip sensors that don't apply to this miner (e.g. fluid/water temperatures on air-cooled miners, chip temperature where the firmware doesn't report it).",
+          "scan_interval": "How often to poll the miner. Lower = fresher data but more load on the miner (default 30 s).",
+          "power_entity": "If set, polling pauses while this switch/sensor is off, then runs a fast boot loop after power-on. Leave empty to always poll.",
+          "boot_timeout": "How long to wait for the miner to come up after power-on before raising the boot-timeout alarm (default 120 s)."
+        }
+      }
+    }
+  },
+  "selector": {
+    "sensor_categories": {
+      "options": {
+        "miner_summary": "Miner summary (hashrate, power, J/TH, temps, uptime, pools)",
+        "safety": "Safety / diagnose (alarm + reason)",
+        "board_temps": "Per-board temperatures (PCB board + inlet/outlet chip temps)",
+        "board_perf": "Per-board performance (hashrate / voltage / frequency / chips)",
+        "fans": "Fans (RPM)"
+      }
+    }
   }
 }

--- a/custom_components/miner/switch.py
+++ b/custom_components/miner/switch.py
@@ -82,10 +82,13 @@ async def async_setup_entry(
 
     entities: list[MinerEntity] = []
 
-    if miner.supports_set_fault_light:
+    # These are gated on miner capability flags. When the miner is None (offline
+    # at startup) we cannot know them, so we skip these native entities; they
+    # appear after the first successful connection + a reload.
+    if miner is not None and miner.supports_set_fault_light:
         entities.append(FaultLightSwitch(coordinator))
 
-    if miner.supports_pause and miner.supports_resume:
+    if miner is not None and miner.supports_pause and miner.supports_resume:
         entities.append(MiningSwitch(coordinator))
 
     async_add_entities(entities)

--- a/custom_components/miner/translations/de.json
+++ b/custom_components/miner/translations/de.json
@@ -1,0 +1,89 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "menu_options": {
+          "manual": "IP-Adresse manuell eingeben",
+          "scan": "Netzwerk nach Minern durchsuchen"
+        }
+      },
+      "manual": {
+        "title": "ASIC-Miner hinzufügen",
+        "description": "Gib die IP-Adresse deines ASIC-Miners ein.",
+        "data": {
+          "host": "IP-Adresse",
+          "username": "Benutzername (optional)",
+          "password": "Passwort (optional)"
+        }
+      },
+      "scan": {
+        "title": "Netzwerk durchsuchen",
+        "description": "Gib das zu durchsuchende Subnetz ein. Es wurde aus deinen Netzwerkeinstellungen vorausgefüllt.",
+        "data": {
+          "subnet": "Subnetz (z. B. 192.168.1.0/24)"
+        }
+      },
+      "scanning": {
+        "title": "Suche läuft …",
+        "description": "{subnet} wird nach ASIC-Minern durchsucht. Das kann bis zu 30 Sekunden dauern."
+      },
+      "pick_miner": {
+        "title": "Miner auswählen",
+        "description": "Wähle einen Miner aus der Liste der im Netzwerk gefundenen Geräte.",
+        "data": {
+          "selected_miner": "Miner"
+        }
+      },
+      "credentials": {
+        "title": "Zugangsdaten",
+        "description": "Gib die Anmeldedaten für {host} ein oder lass die Felder leer, falls keine Authentifizierung nötig ist.",
+        "data": {
+          "username": "Benutzername (optional)",
+          "password": "Passwort (optional)"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Verbindung fehlgeschlagen. Prüfe die IP-Adresse und ob der Miner online ist.",
+      "no_miners_found": "In diesem Subnetz wurden keine Miner gefunden. Versuche einen anderen Bereich.",
+      "unknown": "Unerwarteter Fehler. Prüfe die Home-Assistant-Logs."
+    },
+    "abort": {
+      "already_configured": "Dieser Miner ist bereits konfiguriert."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Miner-Optionen",
+        "description": "Wähle aus, welche Sensor-Kategorien angelegt werden. Eine abgewählte Kategorie wird beim nächsten Neuladen entfernt. Jede Änderung lädt die Integration neu.",
+        "data": {
+          "sensor_categories": "Sensor-Kategorien",
+          "only_available": "Nur typ-relevante Sensoren anlegen",
+          "scan_interval": "Abfrageintervall (Sekunden)",
+          "power_entity": "Strom-Schalter-Entität (optional)",
+          "boot_timeout": "Boot-Timeout (Sekunden)",
+          "password": "Firmware-Web-Passwort (BETA, für VNish)"
+        },
+        "data_description": {
+          "sensor_categories": "Gewünschte Gruppen ankreuzen. Abgewählte Gruppen werden beim Neuladen entfernt.",
+          "only_available": "Sensoren überspringen, die für diesen Miner nicht zutreffen (z. B. Fluid-/Wasser-Temperaturen bei luftgekühlten Minern, Chip-Temperatur wenn die Firmware sie nicht meldet).",
+          "scan_interval": "Wie oft der Miner abgefragt wird. Niedriger = frischere Daten, aber mehr Last auf dem Miner (Default 30 s).",
+          "power_entity": "Wenn gesetzt, pausiert das Polling solange dieser Schalter/Sensor aus ist und läuft nach dem Einschalten in einer schnellen Boot-Schleife. Leer lassen für dauerhaftes Polling.",
+          "boot_timeout": "Wie lange nach dem Einschalten auf den Miner gewartet wird, bevor der Boot-Timeout-Alarm ausgelöst wird (Default 120 s)."
+        }
+      }
+    }
+  },
+  "selector": {
+    "sensor_categories": {
+      "options": {
+        "miner_summary": "Miner-Summary (Hashrate, Leistung, J/TH, Temperaturen, Uptime, Pools)",
+        "safety": "Safety / Diagnose (Alarm + Begründung)",
+        "board_temps": "Pro-Board-Temperaturen (PCB-Board + Inlet-/Outlet-Chip-Temperaturen)",
+        "board_perf": "Pro-Board-Leistung (Hashrate / Spannung / Frequenz / Chips)",
+        "fans": "Lüfter (RPM)"
+      }
+    }
+  }
+}

--- a/custom_components/miner/translations/en.json
+++ b/custom_components/miner/translations/en.json
@@ -24,7 +24,7 @@
         }
       },
       "scanning": {
-        "title": "Scanning\u2026",
+        "title": "Scanning…",
         "description": "Scanning {subnet} for ASIC miners. This may take up to 30 seconds."
       },
       "pick_miner": {
@@ -50,6 +50,40 @@
     },
     "abort": {
       "already_configured": "This miner is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Miner Options",
+        "description": "Tick which sensor categories to create. Unticking a category removes its entities on the next reload. Changing any option reloads the integration.",
+        "data": {
+          "sensor_categories": "Sensor categories",
+          "only_available": "Only create type-relevant sensors",
+          "scan_interval": "Update interval (seconds)",
+          "power_entity": "Power switch entity (optional)",
+          "boot_timeout": "Boot timeout (seconds)",
+          "password": "Firmware web password (BETA, for VNish)"
+        },
+        "data_description": {
+          "sensor_categories": "Tick the groups to create. Unticked groups are removed on reload.",
+          "only_available": "Skip sensors that don't apply to this miner (e.g. fluid/water temperatures on air-cooled miners, chip temperature where the firmware doesn't report it).",
+          "scan_interval": "How often to poll the miner. Lower = fresher data but more load on the miner (default 30 s).",
+          "power_entity": "If set, polling pauses while this switch/sensor is off, then runs a fast boot loop after power-on. Leave empty to always poll.",
+          "boot_timeout": "How long to wait for the miner to come up after power-on before raising the boot-timeout alarm (default 120 s)."
+        }
+      }
+    }
+  },
+  "selector": {
+    "sensor_categories": {
+      "options": {
+        "miner_summary": "Miner summary (hashrate, power, J/TH, temps, uptime, pools)",
+        "safety": "Safety / diagnose (alarm + reason)",
+        "board_temps": "Per-board temperatures (PCB board + inlet/outlet chip temps)",
+        "board_perf": "Per-board performance (hashrate / voltage / frequency / chips)",
+        "fans": "Fans (RPM)"
+      }
     }
   }
 }

--- a/custom_components/miner/vnish.py
+++ b/custom_components/miner/vnish.py
@@ -245,14 +245,22 @@ async def apply_preset(
             body = {}
             with contextlib.suppress(Exception):
                 body = await r.json()
-        if ok and body.get("restart_required"):
-            async with session.post(
-                f"{_base(ip)}/mining/restart", headers=h, timeout=_TIMEOUT
-            ):
-                pass
+        # NOTE (#620, live-verified 2026-06-19 on an S19 Pro Hydro / VNish):
+        # a preset change is applied LIVE by VNish -- frequency, power and
+        # hashrate adopt the new preset within ~30s with no reboot (miner_state
+        # stays "mining", miner_state_time keeps climbing, no re-init). The
+        # ``restart_required`` field in the POST response is the *standing*
+        # device flag, not a per-change verdict: a preceding throttle change
+        # (which itself needs no restart either) sets it sticky-true, so reading
+        # it here triggered unnecessary /mining/restart cycles. We no longer
+        # restart after a preset change.
     except Exception as err:  # noqa: BLE001
         return (False, f"apply failed: {err}")
-    return (ok, f"HTTP {'200' if ok else 'error'} restart={body.get('restart_required')}")
+    return (
+        ok,
+        f"HTTP {'200' if ok else 'error'} "
+        f"restart_required={body.get('restart_required')} (applied live, no restart)",
+    )
 
 
 async def set_throttle(

--- a/custom_components/miner/vnish.py
+++ b/custom_components/miner/vnish.py
@@ -1,0 +1,275 @@
+"""VNish firmware REST client — BETA SOLUTION.
+
+This is an interim, VNish-specific control path. pyasic-rs (asic-rs) currently
+exposes the VNish backend as read-only for power/presets (set_power_limit is an
+unimplemented stub), so this module talks to the VNish firmware REST API
+directly to provide the named-preset and throttle controls.
+
+It is intentionally self-contained and clearly marked BETA: once asic-rs gains
+native VNish write support, the select/number entities should switch to the
+miner object's methods and this module can be dropped.
+
+Endpoints (base = http://{ip}/api/v1):
+  GET  /info               -> firmware identity (fw_name == "Vnish")
+  POST /unlock {pw}        -> {"token": ...}
+  GET  /settings           -> miner.overclock (auth)
+  GET  /autotune/presets   -> autotune preset list (auth)
+  POST /settings           -> apply overclock (auth)
+  GET  /summary            -> miner.miner_status.throttled (unauth)
+  POST /mining/throttle    -> {"percent": N} (auth)
+  POST /mining/restart     -> restart mining (auth)
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+
+import aiohttp
+
+_LOGGER = logging.getLogger(__name__)
+
+_TIMEOUT = aiohttp.ClientTimeout(total=15)
+
+# Non-modded-PSU presets, used as a fallback when the live preset list cannot
+# be fetched (e.g. no password configured). Higher presets (5725..7150) need a
+# modded PSU and are intentionally omitted.
+FALLBACK_PRESETS = [
+    "disabled", "3495", "3635", "3865", "4200", "4250",
+    "4400", "4650", "4855", "5150", "5415", "5560",
+]
+
+THROTTLE_MIN = 20
+THROTTLE_MAX = 100
+
+
+def _base(ip: str) -> str:
+    return f"http://{ip}/api/v1"
+
+
+async def detect_vnish(session: aiohttp.ClientSession, ip: str) -> bool:
+    """Return True if the miner at ip runs VNish firmware."""
+    try:
+        async with session.get(f"{_base(ip)}/info", timeout=_TIMEOUT) as resp:
+            if resp.status != 200:
+                return False
+            info = await resp.json()
+    except Exception:  # noqa: BLE001
+        return False
+    return str(info.get("fw_name", "")).lower() == "vnish"
+
+
+async def _unlock(session: aiohttp.ClientSession, ip: str, pw: str | None) -> str | None:
+    """Obtain an unlock token, or None if it fails (miner off / wrong pw)."""
+    try:
+        async with session.post(
+            f"{_base(ip)}/unlock", json={"pw": pw or ""}, timeout=_TIMEOUT
+        ) as resp:
+            body = await resp.json()
+    except Exception:  # noqa: BLE001
+        return None
+    return body.get("token")
+
+
+async def _fetch_summary_miner(
+    session: aiohttp.ClientSession, ip: str
+) -> dict | None:
+    """GET /summary and return its ``miner`` object (unauth). None on failure."""
+    try:
+        async with session.get(f"{_base(ip)}/summary", timeout=_TIMEOUT) as resp:
+            return (await resp.json()).get("miner", {}) or {}
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _parse_throttle(miner: dict) -> int | None:
+    val = miner.get("miner_status", {}).get("throttled", miner.get("throttled"))
+    try:
+        return int(val) if val is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+async def fetch_status(
+    session: aiohttp.ClientSession, ip: str
+) -> tuple[int | None, str | None]:
+    """Read ``(throttle_percent, miner_state)`` from /summary in one call (unauth).
+
+    ``throttle`` is 100 when unthrottled. ``miner_state`` is VNish's own verdict
+    (e.g. ``mining`` / ``tuning`` / ``initializing`` / ``stopped``), used to
+    surface a friendly "tuning in progress" note without a second request.
+    """
+    miner = await _fetch_summary_miner(session, ip)
+    if miner is None:
+        return (None, None)
+    state = miner.get("miner_status", {}).get("miner_state")
+    return (_parse_throttle(miner), str(state) if state is not None else None)
+
+
+async def fetch_throttle(session: aiohttp.ClientSession, ip: str) -> int | None:
+    """Read the current throttle percent (unauth). 100 == unthrottled."""
+    throttle, _ = await fetch_status(session, ip)
+    return throttle
+
+
+def preset_label(name: str, pretty: str | None, status: str | None) -> str:
+    """Human-readable Select label for a preset option.
+
+    Tuned presets show the firmware's ``pretty`` string with its hashrate
+    estimate (``3495 watt ~ 132 TH`` → ``3495 W ~ 132 TH``); un-tuned numeric
+    presets are marked (``5725 W (untuned)``) so it is clear that selecting one
+    kicks off a tuning cycle first. Non-numeric presets (e.g. ``disabled``) keep
+    their ``pretty``/name as-is.
+    """
+    raw = str(name).strip()
+    if not raw.lstrip("-").isdigit():
+        return (pretty or raw).strip() or raw
+    if (status or "").lower() == "tuned" and pretty:
+        return " ".join(pretty.replace("watt", "W").split())
+    return f"{raw} W (untuned)"
+
+
+async def fetch_presets(
+    session: aiohttp.ClientSession, ip: str, pw: str | None
+) -> list[dict]:
+    """Read the available autotune presets (auth).
+
+    Returns a list of ``{"name", "pretty", "status"}`` dicts (order preserved),
+    or ``[]`` on failure. The name is the canonical value VNish expects; pretty
+    and status drive the Select label via :func:`preset_label`.
+    """
+    token = await _unlock(session, ip, pw)
+    if not token:
+        return []
+    try:
+        async with session.get(
+            f"{_base(ip)}/autotune/presets",
+            headers={"Authorization": token},
+            timeout=_TIMEOUT,
+        ) as resp:
+            presets = await resp.json()
+    except Exception:  # noqa: BLE001
+        return []
+    plist = presets if isinstance(presets, list) else presets.get("presets", [])
+    return [
+        {
+            "name": p["name"],
+            "pretty": p.get("pretty"),
+            "status": p.get("status"),
+        }
+        for p in plist
+        if isinstance(p, dict) and p.get("name")
+    ]
+
+
+async def fetch_current_preset(
+    session: aiohttp.ClientSession, ip: str, pw: str | None
+) -> str | None:
+    """Read the current overclock preset name (auth)."""
+    token = await _unlock(session, ip, pw)
+    if not token:
+        return None
+    try:
+        async with session.get(
+            f"{_base(ip)}/settings",
+            headers={"Authorization": token},
+            timeout=_TIMEOUT,
+        ) as resp:
+            s = await resp.json()
+    except Exception:  # noqa: BLE001
+        return None
+    return s.get("miner", {}).get("overclock", {}).get("preset")
+
+
+async def apply_preset(
+    session: aiohttp.ClientSession, ip: str, pw: str | None, preset: str
+) -> tuple[bool, str]:
+    """Apply an autotune preset by name.
+
+    Ports the proven shim logic: unlock -> GET /settings + /autotune/presets ->
+    POST /settings with the preset + its tune_settings -> restart mining if
+    VNish requires it.
+    """
+    token = await _unlock(session, ip, pw)
+    if not token:
+        return (False, "unlock failed (miner off / wrong pw?)")
+    h = {"Authorization": token}
+    try:
+        async with session.get(f"{_base(ip)}/settings", headers=h, timeout=_TIMEOUT) as r:
+            settings = await r.json()
+        async with session.get(
+            f"{_base(ip)}/autotune/presets", headers=h, timeout=_TIMEOUT
+        ) as r:
+            presets = await r.json()
+    except Exception as err:  # noqa: BLE001
+        return (False, f"read settings/presets failed: {err}")
+
+    plist = presets if isinstance(presets, list) else presets.get("presets", [])
+    tune = None
+    for p in plist:
+        if isinstance(p, dict) and p.get("name") == preset:
+            tune = p.get("tune_settings")
+            break
+
+    oc = settings.get("miner", {}).get("overclock", {})
+    new_oc = dict(oc)
+    new_oc["preset"] = preset
+    if tune:
+        tf, tv = tune.get("freq"), tune.get("volt")
+        if tf is not None or tv is not None:
+            g = dict(new_oc.get("globals", {}))
+            if tf is not None:
+                g["freq"] = tf
+            if tv is not None:
+                g["volt"] = tv // 10  # tune_settings volt is 10x globals (mV vs deciV)
+            new_oc["globals"] = g
+        tch, cch = tune.get("chains", []), new_oc.get("chains", [])
+        if tch and cch:
+            nc = []
+            for i, ch in enumerate(cch):
+                ch = dict(ch)
+                if i < len(tch):
+                    ch["freq"] = tch[i].get("freq", ch.get("freq"))
+                    ch["chips"] = tch[i].get("chips", ch.get("chips"))
+                nc.append(ch)
+            new_oc["chains"] = nc
+
+    try:
+        async with session.post(
+            f"{_base(ip)}/settings",
+            json={"miner": {"overclock": new_oc}},
+            headers=h,
+            timeout=_TIMEOUT,
+        ) as r:
+            ok = r.status == 200
+            body = {}
+            with contextlib.suppress(Exception):
+                body = await r.json()
+        if ok and body.get("restart_required"):
+            async with session.post(
+                f"{_base(ip)}/mining/restart", headers=h, timeout=_TIMEOUT
+            ):
+                pass
+    except Exception as err:  # noqa: BLE001
+        return (False, f"apply failed: {err}")
+    return (ok, f"HTTP {'200' if ok else 'error'} restart={body.get('restart_required')}")
+
+
+async def set_throttle(
+    session: aiohttp.ClientSession, ip: str, pw: str | None, percent: int
+) -> tuple[bool, str]:
+    """Set the throttle (percent of full power, 20..100)."""
+    token = await _unlock(session, ip, pw)
+    if not token:
+        return (False, "unlock failed (miner off / wrong pw?)")
+    try:
+        async with session.post(
+            f"{_base(ip)}/mining/throttle",
+            json={"percent": int(percent)},
+            headers={"Authorization": token},
+            timeout=_TIMEOUT,
+        ) as resp:
+            ok = resp.status == 200
+    except Exception as err:  # noqa: BLE001
+        return (False, f"throttle failed: {err}")
+    return (ok, f"HTTP {'200' if ok else 'error'}")


### PR DESCRIPTION
This is my complete, live-tested asic-rs integration, offered as one branch so you have the full picture for the rewrite — **take it wholesale, or tell me how you'd like it split and I'll carve it up.** It's lib-gated and defensive throughout, so it runs on `pyasic-rs==0.6.2` today and the extra features light up as the matching lib changes land (`set_power_limit` #284 is merged; the 4-field temps pair with #286; the capability/message/thermal-limit bits pair with a few small lib PRs I'm sending next).

Running live on an S19 Pro Hydro (VNish) and an S19K Pro (BraiinsOS).

**On splitting:** focused PRs were the original plan — #604/#605/#606 are exactly that. But the remaining features share files heavily, above all `coordinator.py` (power-aware polling, offline resilience and the VNish poll all live there together), so cleanly splitting the rest into separate PRs is barely feasible without a lot of churn and rebasing. That's why I'm putting it up consolidated and asking how you'd prefer to handle it, rather than forcing an artificial split.

**What's in it**
- **Offline resilience** — load the entry from a cached device profile when the miner is unreachable at startup (entities go `unavailable` instead of failing setup). *(= #604)*
- **Options flow** — configurable scan interval *(= #605)*, sensor-category toggles, only-type-relevant filter, power entity + boot timeout, firmware web password.
- **Power-aware polling** — pause polling while a configured power entity is `off`; fast boot loop + boot-timeout alarm on power-on; only an explicit `off` suppresses polling (unknown/unavailable doesn't).
- **Sensor categories** — group sensors (miner summary / safety / board temps / board perf / fans) and only create the selected groups.
- **Safety** — problem flag + human-readable alarm reason (lib-message + thermal-limit aware), cold/hot limit diagnostics, `tuning in progress` / `powered off` states.
- **4-field temperatures** — per-board inlet/outlet chip + miner-level coolant inlet/outlet.
- **Meaningful icons** for sensors that default to the generic icon. *(= #606)*
- **VNish preset/throttle controls** — BETA REST shim (`vnish.py`), clearly marked; meant to be dropped once asic-rs gains native VNish writes.

**On the overlap:** this incorporates #604/#605/#606. Happy to keep those three as the small focused PRs and rebuild the rest on top, or to land this and close them — whatever's least work for you.
