### PR TITLE
Fix pyasic install race and dependency clobbering on cold start

### DIFF
--- a/custom_components/miner/__init__.py
+++ b/custom_components/miner/__init__.py
@@ -1,8 +1,6 @@
 """The Miner integration."""
 from __future__ import annotations
 
-import sys
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -11,6 +9,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from .const import CONF_IP
 from .const import DOMAIN
 from .const import PYASIC_VERSION
+from .patch import ensure_pyasic
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
@@ -22,34 +21,7 @@ PLATFORMS: list[Platform] = [
 
 def _ensure_pyasic():
     """Ensure pyasic is installed and imported (runs in executor)."""
-
-    def try_import():
-        try:
-            from importlib.metadata import version
-            import pyasic
-            if not hasattr(pyasic, 'get_miner'):
-                raise ImportError("pyasic module incomplete")
-            if version("pyasic") != PYASIC_VERSION:
-                raise ImportError("Version mismatch")
-            return pyasic
-        except Exception:
-            return None
-
-    pyasic = try_import()
-    if pyasic:
-        return pyasic
-
-    # Need to install/reinstall
-    from .patch import install_package
-    install_package(f"pyasic=={PYASIC_VERSION}", force_reinstall=True)
-
-    # Clear any cached broken imports
-    for mod_name in list(sys.modules.keys()):
-        if mod_name.startswith('pyasic'):
-            del sys.modules[mod_name]
-
-    import pyasic
-    return pyasic
+    return ensure_pyasic(PYASIC_VERSION)
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/custom_components/miner/config_flow.py
+++ b/custom_components/miner/config_flow.py
@@ -1,7 +1,5 @@
 """Config flow for Miner."""
 import logging
-import sys
-from importlib.metadata import version
 
 import voluptuous as vol
 from homeassistant import config_entries
@@ -22,6 +20,7 @@ from .const import CONF_WEB_PASSWORD
 from .const import CONF_WEB_USERNAME
 from .const import DOMAIN
 from .const import PYASIC_VERSION
+from .patch import ensure_pyasic
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,29 +36,7 @@ def _ensure_pyasic():
     if pyasic is not None:
         return
 
-    def try_import():
-        try:
-            import pyasic as _pyasic
-            if not hasattr(_pyasic, 'get_miner'):
-                raise ImportError("pyasic module incomplete")
-            if version("pyasic") != PYASIC_VERSION:
-                raise ImportError("Version mismatch")
-            return _pyasic
-        except Exception:
-            return None
-
-    _pyasic = try_import()
-    if _pyasic is None:
-        # Clear any cached broken imports before reinstalling
-        for mod_name in list(sys.modules.keys()):
-            if mod_name.startswith('pyasic'):
-                del sys.modules[mod_name]
-
-        from .patch import install_package
-        install_package(f"pyasic=={PYASIC_VERSION}", force_reinstall=True)
-
-        import pyasic as _pyasic
-
+    _pyasic = ensure_pyasic(PYASIC_VERSION)
     pyasic = _pyasic
     from pyasic import MinerNetwork as _MinerNetwork
     MinerNetwork = _MinerNetwork

--- a/custom_components/miner/patch.py
+++ b/custom_components/miner/patch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import os
 import site
 import sys
+import threading
 from subprocess import PIPE
 from subprocess import Popen
 
@@ -24,6 +25,7 @@ def install_package(
     constraints: str | None = None,
     timeout: int | None = None,
     force_reinstall: bool = False,
+    reinstall_package: str | None = None,
 ) -> bool:
     """Install a package on PyPi. Accepts pip compatible package strings.
 
@@ -53,6 +55,10 @@ def install_package(
         args.append("--upgrade")
     if force_reinstall:
         args.append("--reinstall")
+    if reinstall_package:
+        # Reinstall only this distribution, leaving already-imported shared
+        # dependencies (cryptography, pydantic, httpx, ...) untouched on disk.
+        args += ["--reinstall-package", reinstall_package]
     if constraints is not None:
         args += ["--constraint", constraints]
     if target:
@@ -89,3 +95,54 @@ def install_package(
             return False
 
     return True
+
+
+_PYASIC_LOCK = threading.Lock()
+
+
+def _import_pyasic(expected_version: str):
+    """Import pyasic and validate it; raise ImportError if unusable."""
+    from importlib.metadata import PackageNotFoundError, version
+
+    import pyasic
+
+    if not hasattr(pyasic, "get_miner"):
+        raise ImportError("pyasic module incomplete")
+    try:
+        installed = version("pyasic")
+    except PackageNotFoundError as err:
+        raise ImportError("pyasic metadata missing") from err
+    if installed != expected_version:
+        raise ImportError(f"pyasic {installed} != required {expected_version}")
+    return pyasic
+
+
+def _purge_pyasic_modules() -> None:
+    for mod_name in list(sys.modules):
+        if mod_name == "pyasic" or mod_name.startswith("pyasic."):
+            del sys.modules[mod_name]
+
+
+def ensure_pyasic(expected_version: str):
+    """Return an importable, correctly-versioned pyasic, installing if needed.
+
+    Must be called from an executor thread. Serialized with a process-wide lock:
+    on a fresh container (e.g. after a Core update) several config entries set up
+    concurrently, and without the lock one entry runs ``uv pip install --reinstall``
+    while others import a half-unpacked package -> ModuleNotFoundError -> setup_error.
+    """
+    with _PYASIC_LOCK:
+        try:
+            return _import_pyasic(expected_version)
+        except Exception as err:  # noqa: BLE001 - any import failure means reinstall
+            _LOGGER.info("pyasic unusable (%s); (re)installing %s", err, expected_version)
+
+        _purge_pyasic_modules()
+        if not install_package(
+            f"pyasic=={expected_version}",
+            upgrade=False,
+            reinstall_package="pyasic",
+        ):
+            raise ImportError(f"Failed to install pyasic=={expected_version}")
+        _purge_pyasic_modules()
+        return _import_pyasic(expected_version)


### PR DESCRIPTION
## Problem

After a Home Assistant Core update (fresh container, no `pyasic` in site-packages), every miner config entry calls `_ensure_pyasic()` concurrently. Each one runs `uv pip install --upgrade --reinstall pyasic==X`, which uninstalls and re-unpacks **all ~30 of pyasic's dependencies** (`cryptography`, `pydantic`, `httpx`, `multidict`, `cffi`, `anyio`, ...) — packages Core and other integrations have already imported — while sibling entries `import pyasic` against a half-written tree.

Observed on HA 2026.8.2 with 4 miner entries:

```
ModuleNotFoundError: No module named 'pyasic.miners.whatsminer.btminer.M3X.M30S_Plus_Plus'
ModuleNotFoundError: No module named 'pyasic.miners.antminer.hiveon.X19'
AttributeError: module 'cryptography.utils' has no attribute 'DeprecatedIn50'
```

Entries land in a permanent `setup_error` (no retry). Whether it works on a given boot is pure timing.

## Fix

- Move the install/import logic into a single `patch.ensure_pyasic()` used by both `__init__.py` and `config_flow.py`, serialized with a process-wide `threading.Lock` so only one entry installs and the others reuse the result.
- Use `--reinstall-package pyasic` (and drop `--upgrade`) so only pyasic itself is (re)installed; already-imported shared dependencies are never touched on disk.
- Purge stale `pyasic*` entries from `sys.modules` before and after the install.

## Verification

- 4 threads calling `ensure_pyasic()` with pyasic uninstalled: exactly one `uv pip install`, all 4 succeed, dependency set unchanged (`uv` reports only pyasic reinstalled).
- Cold HA Core restart with pyasic uninstalled: all 4 miner config entries `loaded`, no errors.